### PR TITLE
Minor modifications,  ESLimiter and combine mode 7 removed

### DIFF
--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -170,7 +170,6 @@
 		<text name="COURSEPLAY_SYMMETRIC_LANE_CHANGE" 					 text="Mudança de faixa simétrica" />
 		<text name="COURSEPLAY_UNLOADING_DRIVER_PRIORITY" 				 text="Prioridade do condutor" />
 		<text name="COURSEPLAY_FILLEVEL" 						 text="nivel de enchimento" />
-		<text name="COURSEPLAY_NO_AUTOCOMBINE_MODE_7" 					 text="Ceifeira não suportada" />
 		<text name="COURSEPLAY_PICKUP_JAMMED" 						 text=": carregamento com problemas" />
 		<text name="COURSEPLAY_BALER_NEEDS_NETS" 					 text=": fardos redondos precisam de embalagem" />
 		<text name="COURSEPLAY_SCAN_CURRENT_FIELD_EDGES" 				 text="Calcular a borda do campo atual" />


### PR DESCRIPTION
I've made this changes in order to make sense the meaning of the lights: examples above
![2014-12-16_00002](https://cloud.githubusercontent.com/assets/3687991/5456912/9d660348-8536-11e4-9e34-1130b360c680.jpg)
beacon light on (in the course)

![2014-12-16_00003](https://cloud.githubusercontent.com/assets/3687991/5456933/b5f513b8-8536-11e4-8e1a-c79f39a3f39e.jpg)
beacon lights and hazard lights on (on the course)

![2014-12-16_00005](https://cloud.githubusercontent.com/assets/3687991/5456981/0697124e-8537-11e4-9d66-a08542fb8400.jpg)
beacon light (always on)
