### PR TITLE
Update mode9: fully unloading the shovel

### DIFF
--- a/mode9.lua
+++ b/mode9.lua
@@ -153,7 +153,7 @@ function courseplay:handle_mode9(vehicle, fillLevelPct, allowedToDrive, dt)
 		--courseplay:handleSpecialTools(vehicle,workTool,unfold,lower,turnOn,allowedToDrive,cover,unload)
 		courseplay:handleSpecialTools(vehicle,vehicle,true,nil,nil,nil,nil,nil)
 		local stopUnloading = vehicle.cp.shovel.trailerFound ~= nil and vehicle.cp.shovel.trailerFound.fillLevel >= vehicle.cp.shovel.trailerFound.capacity;
-		if fillLevelPct <= 1 or stopUnloading then
+		if fillLevelPct == 0 or stopUnloading then
 			if vehicle.cp.isLoaded then
 				for i = vehicle.cp.waypointIndex,vehicle.cp.numWaypoints do
 					if vehicle.Waypoints[i].rev then


### PR DESCRIPTION
When bunker is full while unloading (timescale 1x), the unloading isn't continous and will unload only small portions. Those portions are less than 1% and so the shovel won't unload completely with the statement 
if fillLevelPct <= 1 or stopUnloading then

In a first test with the liebherr 432 with the standard multi shovel the new line (fillLevelPct == 0) worked well.