### PR TITLE
Shovelmode 9 improvement

### DIFF
--- a/mode9.lua
+++ b/mode9.lua
@@ -60,12 +60,15 @@ function courseplay:handle_mode9(vehicle, fillLevelPct, allowedToDrive,lx,lz, dt
 			end
 			if vehicle.cp.mode9TargetSilo then
 				if vehicle.cp.BunkerSiloMap == nil then
-				courseplay:debug(('%s: vehicle.cp.mode9TargetSilo = %s call createMap'):format(nameNum(vehicle),tostring(vehicle.cp.mode9TargetSilo.saveId)), 10);
+					courseplay:debug(('%s: vehicle.cp.mode9TargetSilo = %s call createMap'):format(nameNum(vehicle),tostring(vehicle.cp.mode9TargetSilo.saveId)), 10);
 					vehicle.cp.BunkerSiloMap = courseplay:createBunkerSiloMap(vehicle, vehicle.cp.mode9TargetSilo)
 					if vehicle.cp.BunkerSiloMap ~= nil then
 						local stopSearching = false
 						local mostFillLevelAtLine = 0
 						local mostFillLevelIndex = 2
+						
+						--get bunkerFilling
+						local bunkerFilling=courseplay:getBunkerSiloFilling(vehicle.cp.BunkerSiloMap)
 						for lineIndex, line in pairs(vehicle.cp.BunkerSiloMap) do
 							if stopSearching then
 								break
@@ -76,7 +79,8 @@ function courseplay:handle_mode9(vehicle, fillLevelPct, allowedToDrive,lx,lz, dt
 									mostFillLevelAtLine = fillUnit.fillLevel
 									mostFillLevelIndex = column
 								end
-								if column == #line and mostFillLevelAtLine > 0 then
+								
+								if column == #line and mostFillLevelAtLine > math.min(vehicle.cp.shovel.cp.capacity*0.1,200) then --avoid little quantities
 									fillUnit = line[mostFillLevelIndex]
 									if vehicle.cp.mode9SavedLastFillLevel == courseplay:round(fillUnit.fillLevel,1) then
 										courseplay:debug(('%s triesTheSameFillUnit fillLevel: %s'):format(nameNum(vehicle),tostring(vehicle.cp.mode9SavedLastFillLevel)),10)
@@ -87,14 +91,16 @@ function courseplay:handle_mode9(vehicle, fillLevelPct, allowedToDrive,lx,lz, dt
 														column = mostFillLevelIndex;
 																}
 									vehicle.cp.mode9SavedLastFillLevel = courseplay:round(fillUnit.fillLevel,1)
-									
-									stopSearching = true
-									break
+									if bunkerFilling.fillType == fillUnit.fillType or bunkerFilling.fillType == 0 then
+										stopSearching = true
+										courseplay:debug(('%s fillUnit found: %s'):format(nameNum(vehicle),bunkerFilling.fillTypeName),10)
+										break
+									end
 								end
 							end
 						end
 					end
-				else
+				--else
 					
 					
 				
@@ -104,7 +110,8 @@ function courseplay:handle_mode9(vehicle, fillLevelPct, allowedToDrive,lx,lz, dt
 
 
 	-- STATE 2: PREPARE LOADING
-	elseif vehicle.cp.shovelState == 2 then
+	elseif vehicle.cp.shovelState == 2 then	
+
 		if vehicle.cp.mode9TargetSilo and vehicle.cp.BunkerSiloMap and vehicle.cp.actualTarget then
 			local targetUnit = vehicle.cp.BunkerSiloMap[vehicle.cp.actualTarget.line][vehicle.cp.actualTarget.column]
 			local cx , cz = targetUnit.cx, targetUnit.cz
@@ -243,6 +250,7 @@ function courseplay:handle_mode9(vehicle, fillLevelPct, allowedToDrive,lx,lz, dt
 
 	-- STATE 5: UNLOADING
 	elseif vehicle.cp.shovelState == 5 then
+	    vehicle.cp.BunkerSiloMap = nil;
 		--courseplay:handleSpecialTools(vehicle,workTool,unfold,lower,turnOn,allowedToDrive,cover,unload)
 		courseplay:handleSpecialTools(vehicle,vehicle,true,nil,nil,nil,nil,nil)
 		if vehicle.cp.shovel.trailerFound then
@@ -510,7 +518,7 @@ function courseplay:createBunkerSiloMap(vehicle, Silo,width, height)
 	local lastValidfillType = 0
 	local map = {}
 	for heightIndex = 1,heightCount do
-		map[heightIndex]={}
+		map[heightIndex]={}		
 		for widthIndex = 1,widthCount do
 			local newWx = sx + widthLengthX
 			local newWz = sz + widthLengthZ
@@ -551,7 +559,7 @@ function courseplay:createBunkerSiloMap(vehicle, Silo,width, height)
 										fillLevel = newFillLevel;
 										fillType = fillType;
 											}
-											
+			
 			sx = map[heightIndex][widthIndex].wx
 			sz = map[heightIndex][widthIndex].wz
 		end
@@ -583,26 +591,75 @@ function courseplay:createBunkerSiloMap(vehicle, Silo,width, height)
 	return map
 end
 
-function courseplay:getMode9TargetBunkerSilo(vehicle,forcedPoint)
-	local pointIndex = 0
-	if forcedPoint then
-		 pointIndex = forcedPoint;
-	else
-		pointIndex = vehicle.cp.shovelFillStartPoint+1
+--get fillType of silo; calulated by the max fillinglevel
+function courseplay:getBunkerSiloFilling(map)
+	local FillLevels={}
+	local maxValues={fillType=0,fillTypeName="", fillLevel=0,totalFillLevel=0,numFillTypes=0}
+	-- group levels by fillType
+	if map == nil then
+		return maxValues
 	end
-	local x,z = vehicle.Waypoints[pointIndex].cx,vehicle.Waypoints[pointIndex].cz			
-	local tx,tz = x,z + 0.50
-	if g_currentMission.bunkerSilos ~= nil then
-		for _, bunker in pairs(g_currentMission.bunkerSilos) do
-			local x1,z1 = bunker.bunkerSiloArea.sx,bunker.bunkerSiloArea.sz
-			local x2,z2 = bunker.bunkerSiloArea.wx,bunker.bunkerSiloArea.wz
-			local x3,z3 = bunker.bunkerSiloArea.hx,bunker.bunkerSiloArea.hz
-			if Utils.hasRectangleLineIntersection2D(x1,z1,x2-x1,z2-z1,x3-x1,z3-z1,x,z,tx-x,tz-z) then
-				return bunker
+	local fillType
+	for lineIndex, line in pairs(map) do
+		for tileIndex, tile in pairs(line) do 
+			fillType=tile.fillType
+			if  fillType~=nil and fillType ~=0 and tile.fillLevel ~= nil and tile.fillLevel > 0 then
+			    if FillLevels[fillType] == nil then FillLevels[fillType] = 0 end
+				FillLevels[fillType] = FillLevels[fillType]+tile.fillLevel
 			end
 		end
-	else
-		return false
 	end
-	return false
+
+	--calc max values		
+	for i,fillLevel in pairs(FillLevels) do 
+		if fillLevel > maxValues.fillLevel and string.upper(FillUtil.fillTypeIndexToDesc[i].name) ~= "TARP" then --ignore tarp (stuff under the plane))
+			maxValues.fillLevel = fillLevel
+			if FillUtil~=nil and FillUtil.fillTypeIndexToDesc[i] ~= nil then
+				maxValues.fillTypeName=FillUtil.fillTypeIndexToDesc[i].name
+			end
+			courseplay:debug(('Level %s: %d'):format(maxValues.fillTypeName,fillLevel), 10);		
+		end 
+		maxValues.totalFillLevel = maxValues.totalFillLevel + fillLevel
+		maxValues.numFillTypes = maxValues.numFillTypes + 1
+	end	
+	courseplay:debug(('number of types: %d (%d)l'):format(maxValues.numFillTypes,maxValues.totalFillLevel), 10);
+	return maxValues	
+end
+
+function courseplay:getMode9TargetBunkerSilo(vehicle, forcedPoint)
+    local pointIndex = 0
+    local searchPoints = 0;-- look into the next xx waypoints to find the bunker silo
+    if forcedPoint then
+        searchPoints = 5;
+        pointIndex = forcedPoint;
+    else
+        searchPoints = 15;        
+        pointIndex = vehicle.cp.shovelFillStartPoint + 1
+    end
+
+    local x, z
+    local tx, tz
+    repeat
+        if vehicle.Waypoints[pointIndex] == nil then return false end
+        x, z = vehicle.Waypoints[pointIndex].cx, vehicle.Waypoints[pointIndex].cz
+        tx, tz = x, z + 0.50
+        if g_currentMission.bunkerSilos ~= nil then
+            for _, bunker in pairs(g_currentMission.bunkerSilos) do
+                local x1, z1 = bunker.bunkerSiloArea.sx, bunker.bunkerSiloArea.sz
+                local x2, z2 = bunker.bunkerSiloArea.wx, bunker.bunkerSiloArea.wz
+                local x3, z3 = bunker.bunkerSiloArea.hx, bunker.bunkerSiloArea.hz
+                if Utils.hasRectangleLineIntersection2D(x1, z1, x2 - x1, z2 - z1, x3 - x1, z3 - z1, x, z, tx - x, tz - z) then
+                    courseplay:debug(('%s: BunkerSilo found (search,point): %d, %d'):format(nameNum(vehicle),searchPoints, pointIndex), 10);
+                    return bunker
+                end
+            end
+        else
+            return false
+        end
+        searchPoints = searchPoints - 1
+        pointIndex = pointIndex + 1
+        --courseplay:debug(('%s: BunkerSilo still not found (search,point): %d, %d'):format(nameNum(vehicle),searchPoints, pointIndex), 10);
+    until (searchPoints <= 0)
+    courseplay:debug(('%s: no BunkerSilo found, is it just a triggerles heap?'):format(nameNum(vehicle)), 10);
+    return false
 end


### PR DESCRIPTION
I had some problems with it. First of all I didn't even know, that CP is
trying to empty the entire Silo by creating a map and divide it in small
fillUnits.
In front of the Silo on the right wall there was about 40l silage. CP
wanted to load this and was driving allways to the end of the silo. I
couldn't get it to start shovel the rest of the silo.
This is why I changed the fillUnitLevel check >0 to >200 or 10% of
shovelVolume
The Second problem I had. There were 500l Chaff in the wall. CP always
wanted to load it. But because it was completely in the wall it was
impossible to shovel anymore in the silo.
Therefore I let the shoveler always look for a new fillUnit when it
drives into the silo. I also try to compare it with the fillType which
is mostly in the silo.

I created a Video to show the changes of the shoveling in action:
https://youtu.be/gus4_NtwZLo