### PR TITLE
Self Unloading Chaff Harvesters

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="34">
-	<version>5.01.01026</version>
+	<version>5.01.00026</version>
 	<author><![CDATA[Courseplay Dev Team]]></author>
 	<title>
 		<br>Courseplay</br>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="34">
-	<version>5.01.00026</version>
+	<version>5.01.01026</version>
 	<author><![CDATA[Courseplay Dev Team]]></author>
 	<title>
 		<br>Courseplay</br>

--- a/mode6.lua
+++ b/mode6.lua
@@ -89,7 +89,7 @@ function courseplay:handle_mode6(vehicle, allowedToDrive, workSpeed, lx , lz, re
 		end;
 
 		-- implements, no combine or chopper
-		if workTool ~= nil and tool.attachedCutters == nil then
+		if workTool ~= nil and (tool.attachedCutters == nil or (workTool.cp.hasSpecializationTrailer and tool.cp.capacity == 0)) then
 			-- balers
 			if courseplay:isBaler(workTool) then
 				if vehicle.cp.waypointIndex >= vehicle.cp.startWork + 1 and vehicle.cp.waypointIndex < vehicle.cp.stopWork and vehicle.cp.turnStage == 0 then
@@ -378,9 +378,10 @@ function courseplay:handle_mode6(vehicle, allowedToDrive, workSpeed, lx , lz, re
 					allowedToDrive = false;
 				end;
 			end;
+			
 
 		--COMBINES
-		elseif workTool.cp.hasSpecializationCutter then
+		elseif workTool.cp.hasSpecializationCutter and not (workTool.cp.hasSpecializationTrailer and tool.cp.capacity == 0) then
 			--Start combine
 			local isTurnedOn = tool:getIsTurnedOn();
 			local pipeState = 0;
@@ -467,6 +468,7 @@ function courseplay:handle_mode6(vehicle, allowedToDrive, workSpeed, lx , lz, re
 						or tool.waitingForDischarge 
 						or (tool.cp.stopWhenUnloading and tool.overloading ~= nil and  tool.overloading.isActive and tool.courseplayers and tool.courseplayers[1] ~= nil and tool.courseplayers[1].cp.modeState ~= 9) 
 						or tool.stopForManualUnloader then
+							CpManager:setGlobalInfoText(vehicle, 'NEEDS_UNLOADING');
 							tool.waitingForDischarge = true;
 							allowedToDrive = false;
 							if isTurnedOn then

--- a/specialTools.lua
+++ b/specialTools.lua
@@ -37,6 +37,7 @@ function courseplay:setNameVariable(workTool)
 		elseif spec == Sprayer 			   then workTool.cp.hasSpecializationSprayer 			 = true;
 		elseif spec == Steerable 		   then workTool.cp.hasSpecializationSteerable 			 = true;
 		elseif spec == Tedder 			   then workTool.cp.hasSpecializationTedder 			 = true;
+		elseif spec == Trailer 			   then workTool.cp.hasSpecializationTrailer 			 = true;
 		elseif spec == WaterTrailer		   then workTool.cp.hasSpecializationWaterTrailer		 = true;
 		elseif spec == Windrower 		   then workTool.cp.hasSpecializationWindrower 			 = true;
 		elseif spec == Leveler 		   		then workTool.cp.hasSpecializationLeveler 			 = true;


### PR DESCRIPTION
#1362 
Added "need unloading" to combines. Not sure if this was missing or is a bug of my update. Also added back trailer specialization has this is needed for this behavior

Known bug that are related, pipe folding and unfolding is related to something in unload tipper which toggles it but does inhibit functionality, it is also related to turn on but this is good behavior has it need to be unfolded. When tipping through silos it seems to shift by 0.2m when compared to a tractor more testing required. Intial test seem to show that the start and ends are different between the two 

Bug not related but discovered during testing. If a chaff harvester sits to long(more than a few mins) when finish work he will turn on again and just sit there. When turning off the field the harvester is not square to the field though I think turn maneuvers don't support this type of behavior has the sugar beet harvester does this as well(Needs more straight distance away from field). 

Things tested, forage wagon, cultivator, combines, weeders, chaff harvester with mode 10, chaff harvester through and reverse unloading to BGA(this toggles unfolding the pipe), drive now button with chaff harvesters(this does not fold the pipe), and Automatic abort work(this does fold the pipe) and mex 5, ploughs 

Things not tested combines self unloading, baling machines bale loaders and wrappers and the Woodchip header, sugar and potato harvesters

I will do more testing to see if there any other bugs but I am 90% sure I have tested most things that should be affected by this. I really am inserted in this behavior has on GCV most fields don't have enough room to turn around the tipper following a chaff harvester yet. Thanks for reading my book and considering this. If there is anything I can do to improve this just ask. :D Will edit this as I test more stuff