### PR TITLE
Fix for turn singals and hazard lights

### DIFF
--- a/base.lua
+++ b/base.lua
@@ -92,7 +92,7 @@ function courseplay:load(savegame)
 	self.cp.visualWaypointsAll = false;
 	self.cp.visualWaypointsCrossing = false;
 	self.cp.warningLightsMode = 1;
-	self.cp.hasHazardLights = self.turnSignalState ~= nil and self.setTurnSignalState ~= nil;
+	self.cp.hasHazardLights = self.turnLightState ~= nil and self.setTurnLightState ~= nil;
 
 
 	-- saves the shortest distance to the next waypoint (for recocnizing circling)

--- a/drive.lua
+++ b/drive.lua
@@ -171,8 +171,8 @@ function courseplay:drive(self, dt)
 		if self.beaconLightsActive then
 			self:setBeaconLightsVisibility(false);
 		end;
-		if self.cp.hasHazardLights and self.turnSignalState ~= Vehicle.TURNSIGNAL_OFF then
-			self:setTurnSignalState(Vehicle.TURNSIGNAL_OFF);
+		if self.cp.hasHazardLights and self.turnLightState ~= Lights.TURNSIGNAL_OFF then
+			self:setTurnLightState(Lights.TURNLIGHT_OFF);
 		end;
 	else -- on street/always
 		if self.beaconLightsActive ~= beaconOn then
@@ -180,10 +180,10 @@ function courseplay:drive(self, dt)
 		end;
 		if self.cp.hasHazardLights then
 			local hazardOn = self.cp.warningLightsMode == courseplay.WARNING_LIGHTS_BEACON_HAZARD_ON_STREET and beaconOn and not combineBeaconOn;
-			if not hazardOn and self.turnSignalState ~= Vehicle.TURNSIGNAL_OFF then
-				self:setTurnSignalState(Vehicle.TURNSIGNAL_OFF);
-			elseif hazardOn and self.turnSignalState ~= Vehicle.TURNSIGNAL_HAZARD then
-				self:setTurnSignalState(Vehicle.TURNSIGNAL_HAZARD);
+			if not hazardOn and self.turnLightState ~= Lights.TURNLIGHT_OFF then
+				self:setTurnLightState(Lights.TURNLIGHT_OFF);
+			elseif hazardOn and self.turnLightState ~= Lights.TURNLIGHT_HAZARD then
+				self:setTurnLightState(Lights.TURNLIGHT_HAZARD);
 			end;
 		end;
 	end;

--- a/start_stop.lua
+++ b/start_stop.lua
@@ -611,8 +611,8 @@ function courseplay:stop(self)
 	if self.beaconLightsActive then
 		self:setBeaconLightsVisibility(false);
 	end;
-	if self.turnSignalState and self.turnSignalState ~= Vehicle.TURNSIGNAL_OFF then
-		self:setTurnSignalState(Vehicle.TURNSIGNAL_OFF);
+	if self.turnLightState and self.turnLightState ~= Lights.TURNLIGHT_OFF then
+		self:setTurnLightState(Lights.TURNLIGHT_OFF);
 	end;
 
 	--open all covers


### PR DESCRIPTION
Giants changed the variables used for turn signals. This runs with no errors Thought I'd fix something instead of giving you more issues :D. ~~Thing to note the hazards stay on if they are on and you stop CP. If I can change this I will had a new commit~~ [Video](https://www.dropbox.com/s/p9v2pk9g5vd0lhx/Farming%20Simulator%2017%201_23_2017%204_18_16%20PM.mp4?dl=0) of it working 