### PR TITLE
do not turn off engine in mode 10 during leveling

### DIFF
--- a/start_stop.lua
+++ b/start_stop.lua
@@ -758,13 +758,18 @@ function courseplay:checkSaveFuel(vehicle,allowedToDrive)
 	else
 		-- set fuel save timer
 		if not vehicle.cp.saveFuel then
-			if courseplay:timerIsThrough(vehicle,'fuelSaveTimer',false) then
-				--print(" timer is throught and not nil")
-				--print("set saveFuel")
-				vehicle.cp.saveFuel = true
-			elseif courseplay:timerIsThrough(vehicle,'fuelSaveTimer') then
-				--print(" set timer ")
-				courseplay:setCustomTimer(vehicle,'fuelSaveTimer',30)
+			if vehicle.cp.mode == 10 and vehicle.cp.waypointIndex == 1 then
+				-- leveling in mode 1 do not turn off engine
+				vehicle.cp.saveFuel = false
+			else
+				if courseplay:timerIsThrough(vehicle,'fuelSaveTimer',false) then
+					--print(" timer is throught and not nil")
+					--print("set saveFuel")
+					vehicle.cp.saveFuel = true
+				elseif courseplay:timerIsThrough(vehicle,'fuelSaveTimer') then
+					--print(" set timer ")
+					courseplay:setCustomTimer(vehicle,'fuelSaveTimer',30)
+				end
 			end
 		end
 	end


### PR DESCRIPTION
In mode 10 when the tractor is leveling it stays at waypoint1 and the save fuel timer is started and after the timer the engine is stopped. The tractor will still keep on working. This patch fixes it so the timer is not started at waypoint 1 in mode 10.