### PR TITLE
Add button for reload course list.

### DIFF
--- a/button.lua
+++ b/button.lua
@@ -294,7 +294,7 @@ function courseplay.button:render()
 			-- Page 2
 			elseif pg == courseplay.hud.PAGE_MANAGE_COURSES then
 				if fn == "reloadCoursesFromXML" then
-					show = g_server ~= nil;
+					show = g_server ~= nil and not vehicle.cp.canDrive;
 				elseif fn == "showSaveCourseForm" and prm == "filter" then
 					show = not vehicle.cp.hud.choose_parent;
 				elseif fn == 'clearCurrentLoadedCourse' then

--- a/hud.lua
+++ b/hud.lua
@@ -1548,6 +1548,7 @@ function courseplay.hud:setupVehicleHud(vehicle)
 	vehicle.cp.hud.clearCurrentCourseButton2 = courseplay.button:new(vehicle, 2, { 'iconSprite.png', 'courseClear' }, 'clearCurrentLoadedCourse', nil, topIconsX[0], self.topIconsY, wMiddle, hMiddle, nil, nil, false, false, false, courseplay:loc('COURSEPLAY_CLEAR_COURSE'));
 	vehicle.cp.hud.filterButton = courseplay.button:new(vehicle, 2, { 'iconSprite.png', 'search' }, 'showSaveCourseForm', 'filter', topIconsX[1], self.topIconsY, wMiddle, hMiddle, nil, nil, false, false, false, courseplay:loc('COURSEPLAY_SEARCH_FOR_COURSES_AND_FOLDERS'));
 	courseplay.button:new(vehicle, 2, { 'iconSprite.png', 'folderNew' }, 'showSaveCourseForm', 'folder', topIconsX[2], self.topIconsY, wMiddle, hMiddle, nil, nil, false, false, false, courseplay:loc('COURSEPLAY_CREATE_FOLDER'));
+	vehicle.cp.hud.reloadCourses = courseplay.button:new(vehicle, 2, { 'iconSprite.png', 'refresh' }, 'reloadCoursesFromXML', nil, topIconsX[0], self.topIconsY, wMiddle, hMiddle, nil, nil, false, false, false, courseplay:loc('COURSEPLAY_RELOAD_COURSE_LIST'));
 
 
 	-- ##################################################

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -297,7 +297,9 @@
 		<text name="COURSEPLAY_FUEL_SEARCH_FOR"						     text="Reabastecer o tanque de combustível" />
 		<text name="COURSEPLAY_FUEL_ALWAYS"						         text="sempre" />
 		<text name="COURSEPLAY_FUEL_BELOW_20PCT"						 text="abaixo de 20%" />
-		<text name="COURSEPLAY_FUELSAVEOPTION"						     text="Salvar opção para reabastecer" />						 
+		<text name="COURSEPLAY_FUELSAVEOPTION"						     text="Salvar opção para reabastecer" />
+		
+		<text name="COURSEPLAY_RELOAD_COURSE_LIST" 						 text="Reload course list" />            <!-- TODO: TRANSLATION! -->		
 		
 	</texts>
 </l10n>

--- a/translations/translation_cs.xml
+++ b/translations/translation_cs.xml
@@ -297,5 +297,7 @@
 		<text name="COURSEPLAY_FUEL_BELOW_20PCT"						 text="低于20%" />
 		<text name="COURSEPLAY_FUELSAVEOPTION"						     text="省燃油选项" />						 <!-- TODO: TRANSLATE! -->
 		
+		<text name="COURSEPLAY_RELOAD_COURSE_LIST" 						 text="Reload course list" />            <!-- TODO: TRANSLATION! -->
+		
 	</texts>
 </l10n>

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -299,5 +299,7 @@
 		<text name="COURSEPLAY_FUEL_BELOW_20PCT"						 text="méně než 20%" />
 		<text name="COURSEPLAY_FUELSAVEOPTION"						     text="fuel save option" />						 <!-- TODO: TRANSLATE! -->
 		
+		<text name="COURSEPLAY_RELOAD_COURSE_LIST" 						 text="Reload course list" />            <!-- TODO: TRANSLATION! -->
+		
 	</texts>
 </l10n>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -298,6 +298,8 @@
 		<text name="COURSEPLAY_FUEL_BELOW_20PCT"						 text="nur unter 20%" />
 		<text name="COURSEPLAY_FUELSAVEOPTION"						     text="Kraftstoff-Sparmodus" />
 		
+		<text name="COURSEPLAY_RELOAD_COURSE_LIST" 						 text="Reload course list" />            <!-- TODO: TRANSLATION! -->
+		
 		
 	</texts>
 </l10n>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -56,6 +56,7 @@
 		<text name="COURSEPLAY_DELETE_COURSE" 						 	 text="Delete course/folder" />
 		<text name="COURSEPLAY_CREATE_FOLDER" 							 text="Create new folder" />
 		<text name="COURSEPLAY_SEARCH_FOR_COURSES_AND_FOLDERS" 			 text="Search for courses and folders" />
+		<text name="COURSEPLAY_RELOAD_COURSE_LIST" 						 text="Reload course list" />
 		<text name="COURSEPLAY_DEACTIVATE_FILTER" 						 text="Deactivate filter" />
 		<text name="COURSEPLAY_REACHED_OVERLOADING_POINT"				 text="has reached overload point." />
 		<text name="COURSEPLAY_SAVE_PIPE_POSITION" 					     text="save pipe position" /> 

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -56,7 +56,6 @@
 		<text name="COURSEPLAY_DELETE_COURSE" 						 	 text="Delete course/folder" />
 		<text name="COURSEPLAY_CREATE_FOLDER" 							 text="Create new folder" />
 		<text name="COURSEPLAY_SEARCH_FOR_COURSES_AND_FOLDERS" 			 text="Search for courses and folders" />
-		<text name="COURSEPLAY_RELOAD_COURSE_LIST" 						 text="Reload course list" />
 		<text name="COURSEPLAY_DEACTIVATE_FILTER" 						 text="Deactivate filter" />
 		<text name="COURSEPLAY_REACHED_OVERLOADING_POINT"				 text="has reached overload point." />
 		<text name="COURSEPLAY_SAVE_PIPE_POSITION" 					     text="save pipe position" /> 
@@ -299,6 +298,8 @@
 		<text name="COURSEPLAY_FUEL_ALWAYS"						         text="always" />
 		<text name="COURSEPLAY_FUEL_BELOW_20PCT"						 text="below 20%" />
 		<text name="COURSEPLAY_FUELSAVEOPTION"						     text="fuel save option" />
+
+		<text name="COURSEPLAY_RELOAD_COURSE_LIST" 						 text="Reload course list" />
 		
 	</texts>
 </l10n>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -297,5 +297,7 @@
 		<text name="COURSEPLAY_FUEL_BELOW_20PCT"						 text="Por debajo de 20%" />
 		<text name="COURSEPLAY_FUELSAVEOPTION"						     text="Guardar opción combustible." />
 		
+		<text name="COURSEPLAY_RELOAD_COURSE_LIST" 						 text="Reload course list" />            <!-- TODO: TRANSLATION! -->
+		
 	</texts>
 </l10n>

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -298,5 +298,7 @@
 		<text name="COURSEPLAY_FUEL_BELOW_20PCT"						 text="en dessous de 20%" />
 		<text name="COURSEPLAY_FUELSAVEOPTION"						     text="Eco. carburant:" />
 		
+		<text name="COURSEPLAY_RELOAD_COURSE_LIST" 						 text="Reload course list" />            <!-- TODO: TRANSLATION! -->
+		
 	</texts>
 </l10n>

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -297,5 +297,7 @@
 		<text name="COURSEPLAY_FUEL_BELOW_20PCT"						 text="below 20%" />                             <!-- TODO: TRANSLATE! -->
 		<text name="COURSEPLAY_FUELSAVEOPTION"						     text="fuel save option" />						 <!-- TODO: TRANSLATE! -->
 		
+		<text name="COURSEPLAY_RELOAD_COURSE_LIST" 						 text="Reload course list" />            <!-- TODO: TRANSLATION! -->
+		
 	</texts>
 </l10n>

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -299,5 +299,7 @@
 		<text name="COURSEPLAY_FUEL_BELOW_20PCT"						 text="sotto al 20%" />
 		<text name="COURSEPLAY_FUELSAVEOPTION"						     text="Risparmio carburante" />
 		
+		<text name="COURSEPLAY_RELOAD_COURSE_LIST" 						 text="Reload course list" />            <!-- TODO: TRANSLATION! -->
+		
 	</texts>
 </l10n>

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -299,5 +299,7 @@
 		<text name="COURSEPLAY_FUEL_BELOW_20PCT"						 text="20%以下" />
 		<text name="COURSEPLAY_FUELSAVEOPTION"						     text="アイドリングストップ" />
 		
+		<text name="COURSEPLAY_RELOAD_COURSE_LIST" 						 text="Reload course list" />            <!-- TODO: TRANSLATION! -->
+		
 	</texts>
 </l10n>

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -297,5 +297,7 @@
 		<text name="COURSEPLAY_FUEL_BELOW_20PCT"						 text="onder 20%" />
 		<text name="COURSEPLAY_FUELSAVEOPTION"						     text="fuel save option" />						 <!-- TODO: TRANSLATE! -->
 		
+		<text name="COURSEPLAY_RELOAD_COURSE_LIST" 						 text="Reload course list" />            <!-- TODO: TRANSLATION! -->
+		
 	</texts>
 </l10n>

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -299,5 +299,7 @@
 		<text name="COURSEPLAY_FUEL_BELOW_20PCT"						 text="poniżej 20%" />
 		<text name="COURSEPLAY_FUELSAVEOPTION"						     text="Opcja oszczędzania paliwa" />
 		
+		<text name="COURSEPLAY_RELOAD_COURSE_LIST" 						 text="Reload course list" />            <!-- TODO: TRANSLATION! -->
+		
 	</texts>
 </l10n>

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -295,7 +295,9 @@
 		<text name="COURSEPLAY_FUEL_SEARCH_FOR"						     text="Reabastecer o tanque de combustível" />           
 		<text name="COURSEPLAY_FUEL_ALWAYS"						         text="sempre" />                               
 		<text name="COURSEPLAY_FUEL_BELOW_20PCT"						 text="abaixo de 20%" />
-		<text name="COURSEPLAY_FUELSAVEOPTION"						     text="fuel save option" />						 <!-- TODO: TRANSLATE! -->		
+		<text name="COURSEPLAY_FUELSAVEOPTION"						     text="fuel save option" />						 <!-- TODO: TRANSLATE! -->	
+		
+		<text name="COURSEPLAY_RELOAD_COURSE_LIST" 						 text="Reload course list" />            <!-- TODO: TRANSLATION! -->
 		
 	</texts>
 </l10n>

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -56,6 +56,7 @@
 		<text name="COURSEPLAY_DELETE_COURSE" 						 	 text="Удалить" />
 		<text name="COURSEPLAY_CREATE_FOLDER" 							 text="Создать папку" />
 		<text name="COURSEPLAY_SEARCH_FOR_COURSES_AND_FOLDERS" 			 text="Поиск маршрутов и папок" />
+		<text name="COURSEPLAY_RELOAD_COURSE_LIST" 						 text="Обновить список" />
 		<text name="COURSEPLAY_DEACTIVATE_FILTER" 						 text="Отключить поиск" />
 		<text name="COURSEPLAY_REACHED_OVERLOADING_POINT" 				 text="доехал до места разгрузки." />
 		<text name="COURSEPLAY_SAVE_PIPE_POSITION" 					     text="Сохранить позицию трубы" />

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -56,7 +56,6 @@
 		<text name="COURSEPLAY_DELETE_COURSE" 						 	 text="Удалить" />
 		<text name="COURSEPLAY_CREATE_FOLDER" 							 text="Создать папку" />
 		<text name="COURSEPLAY_SEARCH_FOR_COURSES_AND_FOLDERS" 			 text="Поиск маршрутов и папок" />
-		<text name="COURSEPLAY_RELOAD_COURSE_LIST" 						 text="Обновить список" />
 		<text name="COURSEPLAY_DEACTIVATE_FILTER" 						 text="Отключить поиск" />
 		<text name="COURSEPLAY_REACHED_OVERLOADING_POINT" 				 text="доехал до места разгрузки." />
 		<text name="COURSEPLAY_SAVE_PIPE_POSITION" 					     text="Сохранить позицию трубы" />
@@ -299,6 +298,8 @@
 		<text name="COURSEPLAY_FUEL_ALWAYS"								 text="всегда" />
 		<text name="COURSEPLAY_FUEL_BELOW_20PCT"						 text="ниже 20%" />
 		<text name="COURSEPLAY_FUELSAVEOPTION"						     text="Экономить топливо" />
+
+		<text name="COURSEPLAY_RELOAD_COURSE_LIST" 						 text="Обновить список" />
 		
 	</texts>
 </l10n>


### PR DESCRIPTION
Hi. When I plot a course, I sometimes make mistakes and the tractor rests on the haystack or other obstacles. In order not to re-route the route, I use the program for editing the course (yCourse17). When I edited the course and in order for the changes to take effect, I have to go to the main menu and load the save. I added a button to update the list of courses and now you can not go to the main menu. Sorry for my english :)

![fsscreen_2017_04_26_19_58_55](https://cloud.githubusercontent.com/assets/17209082/25455677/591f82f4-2ad9-11e7-8acc-b74750415c8f.png)
