### PR TITLE
Attempt to fix #2211, #2216

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="37">
-	<version>5.01.00178</version>
+	<version>5.01.00179</version>
 	<author><![CDATA[Courseplay Dev Team]]></author>
 	<title>
 		<br>Courseplay</br>


### PR DESCRIPTION
Maybe @ThomasGaertner  reviews this...

1. making sure fruit avoiding path ends far enough from the combine so the tractor won't circle around when reaching the combine (#2211)
2. when trailer is full but there's no last combine, pick one from the reachable combines to be able to call unload_combine and actually drive the combi course (#2216)