### PR TITLE
Fix small updateWaypointSigns bug.  If a sign type is changed it caus…

### DIFF
--- a/helpers.lua
+++ b/helpers.lua
@@ -348,7 +348,7 @@ function courseplay.utils.table.move(t1, t2, t1_index, t2_index)
 	end;
 
 	t2[t2_index] = t1[t1_index];
-	t1[t1_index] = nil;
+	table.remove(t1, t1_index);
 	return t2[t2_index] ~= nil;
 end;
 


### PR DESCRIPTION
…es expansion of the sign array beyond the waypoint count.

Changes courseplay.utils.table.move to table.remove instead of nil assignment.  When addSign inserts a replacement sign later it causes the sign array to expand instead of returning to original array size.