### PR TITLE
Possible fix for #2930

### DIFF
--- a/register.lua
+++ b/register.lua
@@ -21,6 +21,7 @@ if courseplay.houstonWeGotAProblem then
 end;
 
 local numInstallationsVehicles = 0;
+local courseplaySpecName = g_currentModName .. ".courseplay"
 
 function courseplay:register(secondTime)
 	if secondTime then
@@ -31,7 +32,7 @@ function courseplay:register(secondTime)
 	for typeName,vehicleType in pairs(g_vehicleTypeManager.vehicleTypes) do
 		if SpecializationUtil.hasSpecialization(AIVehicle, vehicleType.specializations) and not vehicleType.hasCourseplaySpec then
 				print("  install courseplay into "..typeName)
-				g_vehicleTypeManager:addSpecialization(typeName, g_currentModName .. ".courseplay")
+				g_vehicleTypeManager:addSpecialization(typeName, courseplaySpecName)
 				vehicleType.hasCourseplaySpec = true;
 				numInstallationsVehicles = numInstallationsVehicles + 1;
 		end;


### PR DESCRIPTION
As `g_currentModName` is only available during the loading of scripts for "the current mod", any later usage of `g_currentModName` will not work, as it has become `nil`.

This pull request could possibly fix the #2930 problem.