### PR TITLE
Realistic wages in CpManager.lua

### DIFF
--- a/CpManager.lua
+++ b/CpManager.lua
@@ -842,7 +842,7 @@ end;
 function CpManager:setupWages()
 	self.wageDifficultyMultiplier = 1 --Tommi Utils.lerp(0.5, 1, (g_currentMission.missionInfo.difficulty - 1) / 2);
 	self.wagesActive = true;
-	self.wagePerHour = 1500;
+	self.wagePerHour = 13.50;
 	self.wagePer10Secs  = self.wagePerHour / 360;
 	self.showWagesYesNoDialogue = false;
 end;


### PR DESCRIPTION
I know, this is a very minor thing right now, but I'd at least like you to consider this change. I know of no farm help (in the United States) that makes $1,500.00 per hour. I would assume it's the same whether we're talking dollars, pounds, euros, or whatever currency.

I've always made this change since FS 2013. In FS17 I used 12.50 as the wage value, and the way the wage is figured, it actually became $16.75. Some maps would even boost it somehow to 20 - 22 per hour which is still pretty high, but a far better figure from a realism standpoint. Thank you for your time, and keep up the great work!