### PR TITLE
HuD showing window troubles - Part 1 

### DIFF
--- a/base.lua
+++ b/base.lua
@@ -615,6 +615,8 @@ end;
 function courseplay:onPostLoad(savegame)
 	if savegame ~= nil and savegame.key ~= nil and not savegame.resetVehicles then
 		courseplay.loadVehicleCPSettings(self, savegame.xmlFile, savegame.key, savegame.resetVehicles)
+		--Save the savegame_handle into custom var
+		courseplay.savegame_custom = savegame;
 	end
 
 	-- Drive Control (upsidedown)


### PR DESCRIPTION
Add savegame_handle into a var to re-use after in inputs to reload Vehicle CP Settings just after the modification of preference is saved (it will correct HUD window opening trouble during the game without reloading it).