### PR TITLE
v01.0166 Fixed bouncing speed in turn. Fixes #3312

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="40">
-	<version>6.01.00164</version>
+	<version>6.01.00165</version>
 	<author><![CDATA[Courseplay.devTeam]]></author>
 	<title>
 		<br>CoursePlay SIX</br>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="40">
-	<version>6.01.00165</version>
+	<version>6.01.00166</version>
 	<author><![CDATA[Courseplay.devTeam]]></author>
 	<title>
 		<br>CoursePlay SIX</br>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="40">
-	<version>6.01.00163</version>
+	<version>6.01.00164</version>
 	<author><![CDATA[Courseplay.devTeam]]></author>
 	<title>
 		<br>CoursePlay SIX</br>

--- a/register.lua
+++ b/register.lua
@@ -252,8 +252,8 @@ AIVehicleUtil.driveInDirection = function (self, dt, steeringAngleLimit, acceler
             if math.abs(angle) >= slowAngleLimit then
                 maxSpeed = maxSpeed * slowDownFactor;
             end
-            self.spec_motorized.motor:setSpeedLimit(maxSpeed);
-            if self.spec_drivable.cruiseControl.state ~= Drivable.CRUISECONTROL_STATE_ACTIVE then
+            self:getMotor():setSpeedLimit(maxSpeed);
+            if self:getCruiseControlState() ~= Drivable.CRUISECONTROL_STATE_ACTIVE then
                 self:setCruiseControlState(Drivable.CRUISECONTROL_STATE_ACTIVE);
             end
         else

--- a/turn.lua
+++ b/turn.lua
@@ -805,24 +805,16 @@ function courseplay:turn(vehicle, dt)
 	end
 	allowedToDrive = vehicle.cp.driver and not vehicle.cp.driver:holdInTurnManeuver(vehicle.cp.turnStage == 0) and allowedToDrive
 	
-	--courseplay.debugVehicle(14, vehicle, 'turn speed = %.1f, allowedToDrive %s', refSpeed, allowedToDrive)
-	--vehicle,dt,steeringAngleLimit,acceleration,slowAcceleration,slowAngleLimit,allowedToDrive,moveForwards,lx,lz,maxSpeed,slowDownFactor,angle
-	if curTurnTarget and ((curTurnTarget.turnReverse and reversingWorkTool ~= nil) or (courseplay:onAlignmentCourse( vehicle ) and vehicle.cp.curTurnIndex < 2 )) then
-		if math.abs(vehicle.lastSpeedReal) < 0.0001 and  not g_currentMission.missionInfo.stopAndGoBraking then
-			if not moveForwards then
-				vehicle.nextMovingDirection = -1
-			else
-				vehicle.nextMovingDirection = 1
-			end
+	if math.abs(vehicle.lastSpeedReal) < 0.0001 and  not g_currentMission.missionInfo.stopAndGoBraking then
+		if not moveForwards then
+			vehicle.nextMovingDirection = -1
+		else
+			vehicle.nextMovingDirection = 1
 		end
+	end
 
-		AIVehicleUtil.driveInDirection(vehicle, dt, vehicle.cp.steeringAngle, directionForce, 0.5, 20, allowedToDrive, moveForwards, lx, lz, refSpeed, 1);
-	else
-		-- This code causing the bouncing of the speeds during turns. We must use driveInDirection here to prevent this. As this Giants Function lets us defeine the slow angle limit where as point is a set calc
-		--dtpZ = dtpZ * 0.85;
-		--AIVehicleUtil.driveToPoint(vehicle, dt, directionForce, allowedToDrive, moveForwards, dtpX, dtpZ, refSpeed);
-		AIVehicleUtil.driveInDirection(vehicle, dt, vehicle.cp.steeringAngle, directionForce, 0.5, 20, allowedToDrive, moveForwards, lx, lz, refSpeed, 1);
-	end;
+	AIVehicleUtil.driveInDirection(vehicle, dt, vehicle.cp.steeringAngle, directionForce, 0.5, 20, allowedToDrive, moveForwards, lx, lz, refSpeed, 1);
+
 	courseplay:setTrafficCollision(vehicle, lx, lz, true);
 end;
 

--- a/turn.lua
+++ b/turn.lua
@@ -818,8 +818,10 @@ function courseplay:turn(vehicle, dt)
 
 		AIVehicleUtil.driveInDirection(vehicle, dt, vehicle.cp.steeringAngle, directionForce, 0.5, 20, allowedToDrive, moveForwards, lx, lz, refSpeed, 1);
 	else
-		dtpZ = dtpZ * 0.85;
-		AIVehicleUtil.driveToPoint(vehicle, dt, directionForce, allowedToDrive, moveForwards, dtpX, dtpZ, refSpeed);
+		-- This code causing the bouncing of the speeds during turns. We must use driveInDirection here to prevent this. As this Giants Function lets us defeine the slow angle limit where as point is a set calc
+		--dtpZ = dtpZ * 0.85;
+		--AIVehicleUtil.driveToPoint(vehicle, dt, directionForce, allowedToDrive, moveForwards, dtpX, dtpZ, refSpeed);
+		AIVehicleUtil.driveInDirection(vehicle, dt, vehicle.cp.steeringAngle, directionForce, 0.5, 20, allowedToDrive, moveForwards, lx, lz, refSpeed, 1);
 	end;
 	courseplay:setTrafficCollision(vehicle, lx, lz, true);
 end;


### PR DESCRIPTION
This requires using the driveInDirection function. The driveToPoint function has interal limits that kick back the speed when steering angle is great. diriveInDirection allows us to set when the kickback occurs