### PR TITLE
Fixes #3538. Updates Steering Angle calc

### DIFF
--- a/base.lua
+++ b/base.lua
@@ -356,7 +356,7 @@ function courseplay:onLoad(savegame)
 	-- traffic collision
 	self.cpOnTrafficCollisionTrigger = courseplay.cpOnTrafficCollisionTrigger;
 	if self.maxRotation then
-		self.cp.steeringAngle = math.deg(self.maxRotation);
+		self.cp.steeringAngle = math.deg(self.wheelSteeringDuration);
 	else
 		self.cp.steeringAngle = 30;
 	end

--- a/base.lua
+++ b/base.lua
@@ -355,8 +355,10 @@ function courseplay:onLoad(savegame)
 	
 	-- traffic collision
 	self.cpOnTrafficCollisionTrigger = courseplay.cpOnTrafficCollisionTrigger;
-	if self.maxRotation then
+	if self.wheelSteeringDuration then
 		self.cp.steeringAngle = math.deg(self.wheelSteeringDuration);
+	elseif self.maxRotation then 
+		self.cp.steeringAngle = math.deg(self.maxRotation);
 	else
 		self.cp.steeringAngle = 30;
 	end

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="40">
-	<version>6.01.00166</version>
+	<version>6.01.00167</version>
 	<author><![CDATA[Courseplay.devTeam]]></author>
 	<title>
 		<br>CoursePlay SIX</br>


### PR DESCRIPTION
Swicth steering angle calc to use wheelSteeringDuration instead of maxDuration. This was causing a very high angle to be returned for articulated vehicles. It now returns more reasonbile numbers. 71 degrees for Terra Dos. This idea came from how driveToPoint function determines the steering angle to get to the next point `self.wheelSteeringDuration * ( math.atan(1/radius) / math.atan(1/self.maxTurningRadius) )`