### PR TITLE
Use driveInDirection in all cases for turn.lua

### DIFF
--- a/turn.lua
+++ b/turn.lua
@@ -809,20 +809,16 @@ function courseplay:turn(vehicle, dt)
 	
 	--courseplay.debugVehicle(14, vehicle, 'turn speed = %.1f, allowedToDrive %s', refSpeed, allowedToDrive)
 	--vehicle,dt,steeringAngleLimit,acceleration,slowAcceleration,slowAngleLimit,allowedToDrive,moveForwards,lx,lz,maxSpeed,slowDownFactor,angle
-	if curTurnTarget and ((curTurnTarget.turnReverse and reversingWorkTool ~= nil) or (courseplay:onAlignmentCourse( vehicle ) and vehicle.cp.curTurnIndex < 2 )) then
-		if math.abs(vehicle.lastSpeedReal) < 0.0001 and  not g_currentMission.missionInfo.stopAndGoBraking then
-			if not moveForwards then
-				vehicle.nextMovingDirection = -1
-			else
-				vehicle.nextMovingDirection = 1
-			end
+	if math.abs(vehicle.lastSpeedReal) < 0.0001 and  not g_currentMission.missionInfo.stopAndGoBraking then
+		if not moveForwards then
+			vehicle.nextMovingDirection = -1
+		else
+			vehicle.nextMovingDirection = 1
 		end
+	end
 
-		AIVehicleUtil.driveInDirection(vehicle, dt, vehicle.cp.steeringAngle, directionForce, 0.5, 20, allowedToDrive, moveForwards, lx, lz, refSpeed, 1);
-	else
-		dtpZ = dtpZ * 0.85;
-		AIVehicleUtil.driveToPoint(vehicle, dt, directionForce, allowedToDrive, moveForwards, dtpX, dtpZ, refSpeed);
-	end;
+	AIVehicleUtil.driveInDirection(vehicle, dt, vehicle.cp.steeringAngle, directionForce, 0.5, 20, allowedToDrive, moveForwards, lx, lz, refSpeed, 1);
+
 	courseplay:setTrafficCollision(vehicle, lx, lz, true);
 end;
 


### PR DESCRIPTION
This eliminates the bouncing speed that driveToPoint creates. Tested with articulated axis vehicles and no errors are present. Terra dos needs additional adjustment. I believe the adjustments are made but disabled due to specialTools being outdated. One side note this does seem to causes tractors and combines to not turn as tightly as with point. Causing combines to misses more fruit 