### PR TITLE
Drop delay for silage bales on baler-wrapper-combo after turns

### DIFF
--- a/BaleWrapperAIDriver.lua
+++ b/BaleWrapperAIDriver.lua
@@ -32,21 +32,24 @@ function BaleWrapperAIDriver:driveFieldwork()
 	-- Don't drop the bale in the turn
 	if not self.turnIsDriving then
 	
-		-- inserts unload threshold after turn so bales don't drop on headlands
-		if self.realTurnDurationMs and self.turnStartedAt then
-			local unloadThreshold = 4000 --delay in msecs, 4 secs seems to work well
-			dropTime = 	self.turnStartedAt + self.realTurnDurationMs + unloadThreshold
-		else
-			dropTime = 0 --avoids problems in case of condition variables not existing / empty e.g. before the first turn
-		end
 		-- stop while wrapping only if we deon't have a baler. If we do we should continue driving and working
 		-- on the next bale, the baler code will take care about stopping if we need to
 		if self.baleWrapper.spec_baleWrapper.baleWrapperState ~= BaleWrapper.STATE_NONE and not self.baler then
 			self:setSpeed(0)
 		end
 		-- Yes, Giants has a typo in the state
-		if self.baleWrapper.spec_baleWrapper.baleWrapperState == BaleWrapper.STATE_WRAPPER_FINSIHED and self.vehicle.timer  > dropTime then
-			self.baleWrapper:doStateChange(BaleWrapper.CHANGE_WRAPPER_START_DROP_BALE)
+		if self.baleWrapper.spec_baleWrapper.baleWrapperState == BaleWrapper.STATE_WRAPPER_FINSIHED then
+			-- inserts unload threshold after turn so bales don't drop on headlands
+			if self.turnStartedAt and self.realTurnDurationMs then
+				local unloadThreshold = 4000 --delay in msecs, 4 secs seems to work well
+				dropTime = 	self.turnStartedAt + self.realTurnDurationMs + unloadThreshold
+			else
+				dropTime = 0 --avoids problems in case of condition variables not existing / empty e.g. before the first turn
+			end
+			if self.vehicle.timer  > dropTime then
+				self.baleWrapper:doStateChange(BaleWrapper.CHANGE_WRAPPER_START_DROP_BALE)
+			end
+			
 		end
 	end
 	BalerAIDriver.driveFieldwork(self)

--- a/BaleWrapperAIDriver.lua
+++ b/BaleWrapperAIDriver.lua
@@ -31,13 +31,21 @@ end
 function BaleWrapperAIDriver:driveFieldwork()
 	-- Don't drop the bale in the turn
 	if not self.turnIsDriving then
+	
+		-- inserts unload threshold after turn so bales don't drop on headlands
+		if self.realTurnDurationMs and self.turnStartedAt then
+			local unloadThreshold = 4000 --delay in msecs, 4 secs seems to work well
+			dropTime = 	self.turnStartedAt + self.realTurnDurationMs + unloadThreshold
+		else
+			dropTime = 0 --avoids problems in case of condition variables not existing / empty e.g. before the first turn
+		end
 		-- stop while wrapping only if we deon't have a baler. If we do we should continue driving and working
 		-- on the next bale, the baler code will take care about stopping if we need to
 		if self.baleWrapper.spec_baleWrapper.baleWrapperState ~= BaleWrapper.STATE_NONE and not self.baler then
 			self:setSpeed(0)
 		end
 		-- Yes, Giants has a typo in the state
-		if self.baleWrapper.spec_baleWrapper.baleWrapperState == BaleWrapper.STATE_WRAPPER_FINSIHED then
+		if self.baleWrapper.spec_baleWrapper.baleWrapperState == BaleWrapper.STATE_WRAPPER_FINSIHED and self.vehicle.timer  > dropTime then
 			self.baleWrapper:doStateChange(BaleWrapper.CHANGE_WRAPPER_START_DROP_BALE)
 		end
 	end

--- a/FieldworkAIDriver.lua
+++ b/FieldworkAIDriver.lua
@@ -665,6 +665,7 @@ function FieldworkAIDriver:measureTurnTime()
 		if self.turnStartedAt then
 			-- use sliding average to smooth jumps
 			self.turnDurationMs = (self.turnDurationMs + self.vehicle.timer - self.turnStartedAt) / 2
+			self.realTurnDurationMs = self.vehicle.timer - self.turnStartedAt
 			self:debug('Measured turn duration is %.0f ms', self.turnDurationMs)
 		end
 	elseif not self.turnWasDriving and self.turnIsDriving then


### PR DESCRIPTION
Moin,

I would like to propose a little enhancement to baling operations, especially and in particular silage baling with the baler-wrapper-combo (BWC) :

As I like to have my baling operations being executed fully automatic, I tried to figure out a system which enables the BWC to drive continuously without the risk of colliding with dropped bales. While this is no particular issue on courses with simple up/down rows, it can pose a big issue for fields where one or more headlands are required. I always ran into trouble caused by silage bales blocking the headlands. This issue is not avoidable if you drive the headlands first, because there is always a chance that the tractor will hit the bales once driving the fiield lanes (especially on turns). Vice versa, if you drive the the field lanes first, still some bales would be dropped on the headlands after turns, causing again trouble,,,

As I didn't want to bother you guys with solving the problem, I came up with a solution myself:
I added a drop delay after turns so the bales wouldn't get dropped onto the headlands after turns.

The drop time is calculated by adding the (real) turn time, the time the turn was started and a fixed delay (4 secs seems to work fine). I had to add the calculation for the real turn time since your turn time equation is calculated via mean average and thus doesn't result the "real" turn time.

I tested my solution thourougly (as time allows) and I couldn't find any issues so far. I also tried to program as clean as possible and prepare for any eventualities (nil variables, overflow, etc.)

Here's a small picure of my code at work ;)
![baler_delay](https://user-images.githubusercontent.com/22199380/56150545-6df1f600-5faf-11e9-9f7e-f66391ce2f77.png)

I really appreciate your work. If I can only help this little to improve the experience, I would be really happy. Feel free to contact me about anything.

VIele Grüße,
Seb

