### PR TITLE
Fix pickup lowering conflict  / Improve bale-dropping timing

### DIFF
--- a/BaleWrapperAIDriver.lua
+++ b/BaleWrapperAIDriver.lua
@@ -28,16 +28,9 @@ function BaleWrapperAIDriver:init(vehicle)
 	self.baleWrapper = FieldworkAIDriver.getImplementWithSpecialization(vehicle, BaleWrapper)
 end
 
-function BaleWrapperAIDriver:isOkToDropBale()
-	if self.turnIsDriving or self.fieldworkState == self.states.ON_CONNECTING_TRACK or self.fieldworkState == self.states.TEMPORARY then
-		return false
-	end
-	return true
-end
-
 function BaleWrapperAIDriver:driveFieldwork()
 	-- Don't drop the bale in the turn or on temporary alignment or connecting tracks
-	if self:isOkToDropBale() then
+	if BalerAIDriver.isHandlingAllowed(self) then
 		-- stop while wrapping only if we deon't have a baler. If we do we should continue driving and working
 		-- on the next bale, the baler code will take care about stopping if we need to
 		if self.baleWrapper.spec_baleWrapper.baleWrapperState ~= BaleWrapper.STATE_NONE and not self.baler then

--- a/BaleWrapperAIDriver.lua
+++ b/BaleWrapperAIDriver.lua
@@ -29,9 +29,8 @@ function BaleWrapperAIDriver:init(vehicle)
 end
 
 function BaleWrapperAIDriver:driveFieldwork()
-	-- Don't drop the bale in the turn
-	if not self.turnIsDriving then
-	
+	-- Don't drop the bale in the turn or on temporary alignment or connecting tracks
+	if not self.turnIsDriving and self.fieldworkState ~= self.states.ON_CONNECTING_TRACK and self.fieldworkState ~= self.states.TEMPORARY then
 		-- stop while wrapping only if we deon't have a baler. If we do we should continue driving and working
 		-- on the next bale, the baler code will take care about stopping if we need to
 		if self.baleWrapper.spec_baleWrapper.baleWrapperState ~= BaleWrapper.STATE_NONE and not self.baler then
@@ -39,17 +38,23 @@ function BaleWrapperAIDriver:driveFieldwork()
 		end
 		-- Yes, Giants has a typo in the state
 		if self.baleWrapper.spec_baleWrapper.baleWrapperState == BaleWrapper.STATE_WRAPPER_FINSIHED then
+			-- inserts unload threshold after lowering the implement, useful after e.g. transition from connecting track to fieldwork
+			if self.fieldworkState == self.states.WAITING_FOR_LOWER then
+				local unloadThreshold = 2500 --delay in msecs, 2.5 secs seems to work well
+				loweringDropTime = self.vehicle.timer + unloadThreshold
+			elseif loweringDropTime == nil then
+				loweringDropTime = 0
+			end
 			-- inserts unload threshold after turn so bales don't drop on headlands
 			if self.turnStartedAt and self.realTurnDurationMs then
 				local unloadThreshold = 4000 --delay in msecs, 4 secs seems to work well
-				dropTime = 	self.turnStartedAt + self.realTurnDurationMs + unloadThreshold
+				turnDropTime = self.turnStartedAt + self.realTurnDurationMs + unloadThreshold
 			else
-				dropTime = 0 --avoids problems in case of condition variables not existing / empty e.g. before the first turn
-			end
-			if self.vehicle.timer  > dropTime then
+				turnDropTime = 0 --avoids problems in case of condition variables not existing / empty e.g. before the first turn
+			end		
+			if self.vehicle.timer  > math.max(loweringDropTime,turnDropTime) then --chooses the bigger delay
 				self.baleWrapper:doStateChange(BaleWrapper.CHANGE_WRAPPER_START_DROP_BALE)
 			end
-			
 		end
 	end
 	BalerAIDriver.driveFieldwork(self)

--- a/BaleWrapperAIDriver.lua
+++ b/BaleWrapperAIDriver.lua
@@ -28,9 +28,16 @@ function BaleWrapperAIDriver:init(vehicle)
 	self.baleWrapper = FieldworkAIDriver.getImplementWithSpecialization(vehicle, BaleWrapper)
 end
 
+function BaleWrapperAIDriver:isOkToDropBale()
+	if self.turnIsDriving or self.fieldworkState == self.states.ON_CONNECTING_TRACK or self.fieldworkState == self.states.TEMPORARY then
+		return false
+	end
+	return true
+end
+
 function BaleWrapperAIDriver:driveFieldwork()
 	-- Don't drop the bale in the turn or on temporary alignment or connecting tracks
-	if not self.turnIsDriving and self.fieldworkState ~= self.states.ON_CONNECTING_TRACK and self.fieldworkState ~= self.states.TEMPORARY then
+	if self:isOkToDropBale() then
 		-- stop while wrapping only if we deon't have a baler. If we do we should continue driving and working
 		-- on the next bale, the baler code will take care about stopping if we need to
 		if self.baleWrapper.spec_baleWrapper.baleWrapperState ~= BaleWrapper.STATE_NONE and not self.baler then

--- a/BalerAIDriver.lua
+++ b/BalerAIDriver.lua
@@ -40,9 +40,8 @@ function BalerAIDriver:allFillLevelsOk()
 end
 
 function BalerAIDriver:handleBaler()
-	-- turn.lua will raise/lower as needed, don't touch the balers while the turn maneuver is executed
-	if self.turnIsDriving then return end
-
+	-- turn.lua will raise/lower as needed, don't touch the balers while the turn maneuver is executed or while on temporary alignment / connecting track
+	if self.turnIsDriving or self.fieldworkState == self.states.ON_CONNECTING_TRACK or self.fieldworkState == self.states.TEMPORARY then return end
 	--if vehicle.cp.waypointIndex >= vehicle.cp.startWork + 1 and vehicle.cp.waypointIndex < vehicle.cp.stopWork and vehicle.cp.turnStage == 0 then
 	--  vehicle, self.baler, unfold, lower, turnOn, allowedToDrive, cover, unload, ridgeMarker,forceSpeedLimit,workSpeed)
 	local specialTool, allowedToDrive, stoppedForReason = courseplay:handleSpecialTools(self.vehicle, self.baler, true, true, true, true, nil, nil, nil);
@@ -51,7 +50,6 @@ function BalerAIDriver:handleBaler()
 		local capacity = self.baler.cp.capacity
 		local fillLevel = self.baler.cp.fillLevel
 		if self.baler.spec_baler ~= nil then
-
 			--print(string.format("if courseplay:isRoundbaler(self.baler)(%s) and fillLevel(%s) > capacity(%s) * 0.9 and fillLevel < capacity and self.baler.spec_baler.unloadingState(%s) == Baler.UNLOADING_CLOSED(%s) then",
 			--tostring(courseplay:isRoundbaler(self.baler)),tostring(fillLevel),tostring(capacity),tostring(self.baler.spec_baler.unloadingState),tostring(Baler.UNLOADING_CLOSED)))
 			if courseplay:isRoundbaler(self.baler) and fillLevel > capacity * 0.9 and fillLevel < capacity and self.baler.spec_baler.unloadingState == Baler.UNLOADING_CLOSED then

--- a/BalerAIDriver.lua
+++ b/BalerAIDriver.lua
@@ -39,9 +39,16 @@ function BalerAIDriver:allFillLevelsOk()
 	return true
 end
 
+function BalerAIDriver:handlingIsAllowed()
+	if self.turnIsDriving or self.fieldworkState == self.states.ON_CONNECTING_TRACK or self.fieldworkState == self.states.TEMPORARY  then
+		return false
+	end
+	return true
+end
+
 function BalerAIDriver:handleBaler()
 	-- turn.lua will raise/lower as needed, don't touch the balers while the turn maneuver is executed or while on temporary alignment / connecting track
-	if self.turnIsDriving or self.fieldworkState == self.states.ON_CONNECTING_TRACK or self.fieldworkState == self.states.TEMPORARY then return end
+	if not self:handlingIsAllowed() then return end
 	--if vehicle.cp.waypointIndex >= vehicle.cp.startWork + 1 and vehicle.cp.waypointIndex < vehicle.cp.stopWork and vehicle.cp.turnStage == 0 then
 	--  vehicle, self.baler, unfold, lower, turnOn, allowedToDrive, cover, unload, ridgeMarker,forceSpeedLimit,workSpeed)
 	local specialTool, allowedToDrive, stoppedForReason = courseplay:handleSpecialTools(self.vehicle, self.baler, true, true, true, true, nil, nil, nil);
@@ -54,8 +61,8 @@ function BalerAIDriver:handleBaler()
 			--tostring(courseplay:isRoundbaler(self.baler)),tostring(fillLevel),tostring(capacity),tostring(self.baler.spec_baler.unloadingState),tostring(Baler.UNLOADING_CLOSED)))
 			if courseplay:isRoundbaler(self.baler) and fillLevel > capacity * 0.9 and fillLevel < capacity and self.baler.spec_baler.unloadingState == Baler.UNLOADING_CLOSED then
 				if not self.baler.spec_turnOnVehicle.isTurnedOn and not stoppedForReason then
-					self.baler:setIsTurnedOn(true, false);
-				end;
+					self.baler:setIsTurnedOn(true, false)
+				end
 				self:setSpeed(self.vehicle.cp.speeds.turn)
 			elseif fillLevel >= capacity and self.baler.spec_baler.unloadingState == Baler.UNLOADING_CLOSED then
 				allowedToDrive = false;
@@ -73,10 +80,10 @@ function BalerAIDriver:handleBaler()
 		end
 		if self.baler.setPickupState ~= nil then
 			if self.baler.spec_pickup ~= nil and not self.baler.spec_pickup.isLowered then
-				self.baler:setPickupState(true, false);
+				self.baler:setPickupState(true, false)
 				courseplay:debug('lowering baler pickup')
-			end;
-		end;
+			end
+		end
 	end
 	if not allowedToDrive then
 		self:setSpeed(0)

--- a/BalerAIDriver.lua
+++ b/BalerAIDriver.lua
@@ -39,7 +39,7 @@ function BalerAIDriver:allFillLevelsOk()
 	return true
 end
 
-function BalerAIDriver:handlingIsAllowed()
+function BalerAIDriver:isHandlingAllowed()
 	if self.turnIsDriving or self.fieldworkState == self.states.ON_CONNECTING_TRACK or self.fieldworkState == self.states.TEMPORARY  then
 		return false
 	end
@@ -48,7 +48,7 @@ end
 
 function BalerAIDriver:handleBaler()
 	-- turn.lua will raise/lower as needed, don't touch the balers while the turn maneuver is executed or while on temporary alignment / connecting track
-	if not self:handlingIsAllowed() then return end
+	if not self:isHandlingAllowed() then return end
 	--if vehicle.cp.waypointIndex >= vehicle.cp.startWork + 1 and vehicle.cp.waypointIndex < vehicle.cp.stopWork and vehicle.cp.turnStage == 0 then
 	--  vehicle, self.baler, unfold, lower, turnOn, allowedToDrive, cover, unload, ridgeMarker,forceSpeedLimit,workSpeed)
 	local specialTool, allowedToDrive, stoppedForReason = courseplay:handleSpecialTools(self.vehicle, self.baler, true, true, true, true, nil, nil, nil);


### PR DESCRIPTION
Moin,

here's a small fix (plus some enhancements), again for baling...

Last days, I had a few issues on courses when connecting tracks were identical to consecutive headlands (e.g. happening on certain circumstances after Fieldlane-> Headland transitions). During investigation, I also found that the baler had still lowered its pickup while driving on the connecting track with field speed (Issue applied to balers and wrapper combos). That's the one I fixed.

Further, I was sometimes annoyed by another behaviour: When starting or returning to a course, the baler would instantly drop any bale, meaning it would leave the bale wherever it started the temporary (alignment / transfer) course

Also, I added another drop delay. This one delays dropping bales after the pickup was lowered, helping with certain issues e.g. avoiding to drop a bale on a connecting track segment (this sometimes caused collisions with bales on headland changes).

If you have any question or further annotations, feel free to ask.

Viele Grüße,
Seb

------------------------------------------------------------------

**Fixes:**
- Pickup was lowered on connecting tracks, causing multiple issues. Issue triggered by BalerAIDriver.lua overriding turn.lua's command to raise the pickup.

**Improvements:**
- Bales are not dropped on temporary alignment paths, only on field lanes. Avoids instantly dropping the bale on starting or returning to a course.
- Bale drop delay added after lowering the pickup. Avoids e.g. bales dropping on connecting tracks.
- Bale drop delay is now chosen depending on which condition drops later (Turn Delay or Lowering Delay)