### PR TITLE
Bugfix #3989

### DIFF
--- a/AIDriver.lua
+++ b/AIDriver.lua
@@ -151,7 +151,7 @@ function AIDriver:init(vehicle)
 	-- same for allowedToDrive, is reset at the end of each loop to true and needs to be set to false
 	-- if someone wants to stop by calling hold()
 	self.allowedToDrive = true
-	self.collisionDetectionEnabled = false
+	self.collisionDetectionEnabled = true
 	self.collisionDetector = CollisionDetector(self.vehicle)
 	-- list of active messages to display
 	self.activeMsgReferences = {}

--- a/AIDriver.lua
+++ b/AIDriver.lua
@@ -152,7 +152,6 @@ function AIDriver:init(vehicle)
 	-- if someone wants to stop by calling hold()
 	self.allowedToDrive = true
 	self.collisionDetectionEnabled = true
-	-- self.collisionDetector = CollisionDetector(self.vehicle)
 	self.collisionDetector = nil
 	-- list of active messages to display
 	self.activeMsgReferences = {}
@@ -219,8 +218,8 @@ end
 
 --- Dismiss the driver
 function AIDriver:dismiss()
-	if self.collisionDetector then		-- restore the default direction of the colli boxes
-		self.collisionDetector:reset()
+	if self.collisionDetector then
+		self.collisionDetector:reset()		-- restore the default direction of the colli boxes
 	end
 	self.vehicle:deactivateLights()
 	self:clearAllInfoTexts()
@@ -230,6 +229,7 @@ end
 --- Stop the driver
 -- @param reason as defined in globalInfoText.msgReference
 function AIDriver:stop(msgReference)
+	self:deleteCollisionDetector()
 	-- not much to do here, see the derived classes
 	self:setInfoText(msgReference)
 	self.state = self.states.STOPPED
@@ -1357,4 +1357,14 @@ end
 
 function AIDriver:onUnBlocked()
 	self:debug('Unblocked...')
+end
+
+function AIDriver:isInTraffic(dt)
+	if self.collisionDetector then
+		local isInTraffic, trafficSpeed = self.collisionDetector:getStatus(dt)
+		if isInTraffic then
+			self:hold()
+		end
+	end
+	return self.allowedToDrive
 end

--- a/AIDriver.lua
+++ b/AIDriver.lua
@@ -741,6 +741,7 @@ function AIDriver:detectCollision(dt)
 		self:clearInfoText('TRAFFIC')
 	end
 
+	return self.allowedToDrive
 end
 
 function AIDriver:areBeaconLightsEnabled()
@@ -1357,14 +1358,4 @@ end
 
 function AIDriver:onUnBlocked()
 	self:debug('Unblocked...')
-end
-
-function AIDriver:isInTraffic(dt)
-	if self.collisionDetector then
-		local isInTraffic, trafficSpeed = self.collisionDetector:getStatus(dt)
-		if isInTraffic then
-			self:hold()
-		end
-	end
-	return self.allowedToDrive
 end

--- a/AIDriver.lua
+++ b/AIDriver.lua
@@ -152,7 +152,8 @@ function AIDriver:init(vehicle)
 	-- if someone wants to stop by calling hold()
 	self.allowedToDrive = true
 	self.collisionDetectionEnabled = true
-	self.collisionDetector = CollisionDetector(self.vehicle)
+	-- self.collisionDetector = CollisionDetector(self.vehicle)
+	self.collisionDetector = nil
 	-- list of active messages to display
 	self.activeMsgReferences = {}
 	self.pathfinder = Pathfinder()
@@ -196,7 +197,9 @@ end
 function AIDriver:beforeStart()
 	self.turnIsDriving = false
 	self.nextCourse = nil
-	-- self:deleteCollisionDetector()		-- makes no sense to delete the detector here
+	if self.collisionDetector == nil then
+		self.collisionDetector = CollisionDetector(self.vehicle)
+	end
 	self:startEngineIfNeeded()
 end
 

--- a/FieldworkAIDriver.lua
+++ b/FieldworkAIDriver.lua
@@ -339,7 +339,7 @@ end
 
 function FieldworkAIDriver:changeToFieldwork()
 	self:debug('change to fieldwork')
-	self:disableCollisionDetection()
+	-- self:disableCollisionDetection()
 	self.state = self.states.ON_FIELDWORK_COURSE
 	self.fieldworkState = self.states.WAITING_FOR_LOWER
 	self:startWork()

--- a/FieldworkAIDriver.lua
+++ b/FieldworkAIDriver.lua
@@ -339,7 +339,6 @@ end
 
 function FieldworkAIDriver:changeToFieldwork()
 	self:debug('change to fieldwork')
-	-- self:disableCollisionDetection()
 	self.state = self.states.ON_FIELDWORK_COURSE
 	self.fieldworkState = self.states.WAITING_FOR_LOWER
 	self:startWork()

--- a/TrafficCollision.lua
+++ b/TrafficCollision.lua
@@ -164,7 +164,7 @@ function CollisionDetector:getStatus(dt)
 				if collidingVehicle.isCpPathVehicle then
 					self:setPathVehiclesSpeed(collidingVehicle, dt)
 				end
-				if collidingVehicle.lastSpeedReal == nil or collidingVehicle.lastSpeedReal*3600 == 0 or not self:doesVehicleGoMyDirection(collidingVehicleId) then
+				if collidingVehicle.lastSpeedReal == nil or collidingVehicle.lastSpeedReal*3600 < 0.01 then		-- collidingVehicle not moving -> STOP
 					isInTraffic = true
 				else	
 					trafficSpeed = collidingVehicle.lastSpeedReal*3600

--- a/TrafficCollision.lua
+++ b/TrafficCollision.lua
@@ -31,6 +31,7 @@ function CollisionDetector:init(vehicle, course)
 	self.ignoredNodes = {}
 	self:addToIgnoreList(self.vehicle)
 	self.trafficCollisionTriggers = {}
+	self.trafficCollisionTriggers[1] = nil
 	self:createTriggers()
 	self:adaptCollisHeight()
 end
@@ -83,7 +84,6 @@ function CollisionDetector:createTriggers()
 			end;
 			addTrigger(newTrigger, 'onCollision', self)
 		end;
-		addTrigger(newTrigger, 'onCollision', self)
 	end
 end
 
@@ -113,10 +113,10 @@ function CollisionDetector:addToIgnoreList(object)
 	self.ignoredNodes[object.rootNode] = true;
 	-- add the vehicle or implement's own collision trigger to the ignore list
 	-- local aiCollisionTrigger = courseplay:findAiCollisionTrigger(object)
-	if not courseplay:findAiCollisionTrigger(object) then return end
-	if object.aiCollisionTrigger then
-		self:debug('-- %q', getName(object.aiCollisionTrigger))
-		self.ignoredNodes[object.aiCollisionTrigger] = true
+	courseplay:findAiCollisionTrigger(object)		-- get aiTrafficCollisionTrigger for vehicles
+	if object.aiTrafficCollisionTrigger then
+		self:debug('-- %q', getName(object.aiTrafficCollisionTrigger))
+		self.ignoredNodes[object.aiTrafficCollisionTrigger] = true
 	end
 	if object.components then
 		self:debug('will ignore collisions with %q (%q) components', nameNum(object), tostring(object.cp.xmlFileName))

--- a/TrafficCollision.lua
+++ b/TrafficCollision.lua
@@ -47,7 +47,6 @@ function CollisionDetector:delete()
 		self.collidingObjects = {}				-- clear all detected collisions
 		self.nCollidingObjects = 0				-- clear all detected collisions
 		self.ignoredNodes = {}					-- clear all detected collisions
-		self:addToIgnoreList(self.vehicle)
 	end
 end
 
@@ -71,18 +70,21 @@ function CollisionDetector:createTriggers()
 	end
 	self.vehicle.cp.trafficCollisionTriggerToTriggerIndex = {}
 	-- self.vehicle.aiTrafficCollisionTrigger = self.aiTrafficCollisionTrigger
-	for i = 1, self.vehicle.cp.numTrafficCollisionTriggers do
-		local newTrigger = clone(self.vehicle.aiTrafficCollisionTrigger, true)
-		self.trafficCollisionTriggers[i] = newTrigger
-		self.vehicle.cp.trafficCollisionTriggerToTriggerIndex[newTrigger] = i;
-		setName(newTrigger, 'cpAiCollisionTrigger ' .. tostring(i))
-		if i > 1 then
-			unlink(newTrigger)
-			link(self.trafficCollisionTriggers[i - 1], newTrigger)
-			setTranslation(newTrigger, 0, 0, 4)
+	if self.trafficCollisionTriggers[1] == nil then
+		for i = 1, self.vehicle.cp.numTrafficCollisionTriggers do
+			local newTrigger = clone(self.vehicle.aiTrafficCollisionTrigger, true)
+			self.trafficCollisionTriggers[i] = newTrigger
+			self.vehicle.cp.trafficCollisionTriggerToTriggerIndex[newTrigger] = i;
+			setName(newTrigger, 'cpAiCollisionTrigger ' .. tostring(i))
+			if i > 1 then
+				unlink(newTrigger)
+				link(self.trafficCollisionTriggers[i - 1], newTrigger)
+				setTranslation(newTrigger, 0, 0, 4)
+			end;
+			addTrigger(newTrigger, 'onCollision', self)
 		end;
 		addTrigger(newTrigger, 'onCollision', self)
-	end;
+	end
 end
 
 
@@ -98,6 +100,7 @@ function CollisionDetector:deleteTriggers()
 				delete(node)
 			end
 		end
+		self.trafficCollisionTriggers[i] = nil
 	end
 
 end

--- a/turn.lua
+++ b/turn.lua
@@ -696,7 +696,7 @@ function courseplay:turn(vehicle, dt, turnContext)
 
 	if vehicle.cp.drivingMode:get() == DrivingModeSetting.DRIVING_MODE_AIDRIVER then
 		-- in AIDriver based modes do not call / use legacy collision code
-				allowedToDrive = AIDriver:isInTraffic(dt)
+				allowedToDrive = vehicle.cp.driver:detectCollision(dt)
 	else
 		-- allowedToDrive = courseplay:checkTraffic(self, true, allowedToDrive)
 	end

--- a/turn.lua
+++ b/turn.lua
@@ -693,6 +693,20 @@ function courseplay:turn(vehicle, dt, turnContext)
 	----------------------------------------------------------
 	--allowedToDrive = allowedToDrive and not courseplay:needToWaitForTools(vehicle)
 
+
+	if vehicle.cp.drivingMode:get() == DrivingModeSetting.DRIVING_MODE_AIDRIVER then
+		-- in AIDriver based modes do not call / use legacy collision code
+		if vehicle.cp.driver.collisionDetector then
+			-- TODO pvaiko - decide to take this dirty traffic STOP for AIDriver based modes
+			local isInTraffic, trafficSpeed = vehicle.cp.driver.collisionDetector:getStatus(dt)
+			if isInTraffic then
+				allowedToDrive = false
+			end
+		end
+	else
+		-- allowedToDrive = courseplay:checkTraffic(self, true, allowedToDrive)
+	end
+
 	----------------------------------------------------------
 	-- allowedToDrive false -> SLOW DOWN TO STOP
 	----------------------------------------------------------

--- a/turn.lua
+++ b/turn.lua
@@ -696,13 +696,7 @@ function courseplay:turn(vehicle, dt, turnContext)
 
 	if vehicle.cp.drivingMode:get() == DrivingModeSetting.DRIVING_MODE_AIDRIVER then
 		-- in AIDriver based modes do not call / use legacy collision code
-		if vehicle.cp.driver.collisionDetector then
-			-- TODO pvaiko - decide to take this dirty traffic STOP for AIDriver based modes
-			local isInTraffic, trafficSpeed = vehicle.cp.driver.collisionDetector:getStatus(dt)
-			if isInTraffic then
-				allowedToDrive = false
-			end
-		end
+				allowedToDrive = AIDriver:isInTraffic(dt)
 	else
 		-- allowedToDrive = courseplay:checkTraffic(self, true, allowedToDrive)
 	end

--- a/vehicles.lua
+++ b/vehicles.lua
@@ -1549,7 +1549,7 @@ function courseplay:findAiCollisionTrigger(vehicle)
 		end;
 	end;
 
-	if vehicle.aiTrafficCollisionTrigger == nil then
+	if vehicle.aiTrafficCollisionTrigger == nil and SpecializationUtil.hasSpecialization(AIVehicle, vehicle.specializations) then
 		print(string.format('## Courseplay: aiTrafficCollisionTrigger missing. Traffic collision prevention will not work! vehicle %s', nameNum(vehicle)));
 	end;
 


### PR DESCRIPTION
enable collision detection during field work
- in AIDriver.lua enable collision detection by default in init(vehicle)
- in FieldworkAIDriver.lua disabled self:disableCollisionDetection() in changeToFieldwork()
- in TrafficCollision.lua getStatus(dt) raise isInTraffic for colliding vehicles which do not move
- in turn.lua added collision detection from AIDriver based modes 
