### PR TITLE
Bugfix 4004

### DIFF
--- a/TrafficCollision.lua
+++ b/TrafficCollision.lua
@@ -63,7 +63,8 @@ end
 -- so they form a snake in front of the vehicle along the path. When this snakes collides with something, the
 -- the onCollision() callback is triggered by the game engine
 function CollisionDetector:createTriggers()
-	if not courseplay:findAiCollisionTrigger(self.vehicle) then return end
+
+	if not courseplay:findAiCollisionTrigger(self.vehicle) then return end	-- create triggers only for enterable vehicles
 	-- self.aiTrafficCollisionTrigger = courseplay:findAiCollisionTrigger(self.vehicle)
 	-- if not self.aiTrafficCollisionTrigger then return end
 	if not self.trafficCollisionTriggers then

--- a/combines.lua
+++ b/combines.lua
@@ -259,6 +259,7 @@ function courseplay:unregisterFromCombine(vehicle, combine)
 
 	vehicle.allow_follwing = false
 	vehicle.cp.positionWithCombine = nil
+	courseplay:removeFromVehicleLocalIgnoreList(vehicle, combine)
 	vehicle.cp.lastActiveCombine = vehicle.cp.activeCombine
 	vehicle.cp.activeCombine = nil
 	courseplay:setModeState(vehicle, 1);

--- a/mode2.lua
+++ b/mode2.lua
@@ -202,6 +202,7 @@ function courseplay:handle_mode2(vehicle, dt)
 				if vehicle.cp.lastActiveCombine ~= nil then
 					local distance = courseplay:distanceToObject(vehicle, vehicle.cp.lastActiveCombine)
 					if distance > 20 or vehicle.cp.totalFillLevelPercent == 100 then
+						courseplay:removeFromVehicleLocalIgnoreList(vehicle, vehicle.cp.lastActiveCombine)
 						vehicle.cp.lastActiveCombine = nil
 						courseplay:debug(string.format("%s (%s): last combine = nil", nameNum(vehicle), tostring(vehicle.id)), 4);
 					else
@@ -323,7 +324,8 @@ function courseplay:handle_mode2(vehicle, dt)
 	if vehicle.cp.hasDriveControl and vehicle.cp.driveControl.hasFourWD then
 		--courseplay:setFourWheelDrive(vehicle); disabled, already moved to AIDriver
 	end;
-end
+	return true
+end		-- end handle_mode2()
 
 function courseplay:unload_combine(vehicle, dt)
 	local curFile = "mode2.lua"
@@ -1318,7 +1320,7 @@ function courseplay:unload_combine(vehicle, dt)
 		local combine = vehicle.cp.activeCombine or vehicle.cp.lastActiveCombine
 		local distanceToCombine = math.huge
 		--reasons for not calling bypassing in 50m range
-		if combine ~= nil and (combine.cp.isChopper or vehicle.cp.driveUnloadNow or vehicle.cp.totalFillLevel >= vehicle.cp.totalCapacity) then
+		if combine ~= nil then
 			distanceToCombine = courseplay:distanceToObject( vehicle, combine )  	
 		end
 		if distanceToCombine > 50 and ((vehicle.cp.modeState == STATE_FOLLOW_TARGET_WPS and not vehicle.cp.curTarget.turn and not vehicle.cp.curTarget.rev and not vehicle.cp.isParking ) or vehicle.cp.modeState == STATE_DRIVE_TO_COMBINE) then   
@@ -1336,8 +1338,9 @@ function courseplay:unload_combine(vehicle, dt)
 			lx, lz = courseplay:isTheWayToTargetFree(vehicle, lx, lz, tx, tz,dod )
 		end
 		
-				-- courseplay:setTrafficCollision(vehicle, lx, lz,true)
-		courseplay:setTrafficCollisionOnField(vehicle, lx, lz,false)				
+		courseplay:addToVehicleLocalIgnoreList(vehicle, combine)
+
+		courseplay:setTrafficCollisionOnField(vehicle, lx, lz,false,distanceToCombine)
 		
 		if math.abs(vehicle.lastSpeedReal) < 0.0001 and not g_currentMission.missionInfo.stopAndGoBraking then
 			if not moveForwards then

--- a/register.lua
+++ b/register.lua
@@ -172,6 +172,7 @@ function courseplay:vehicleDelete()
 						courseplay:unregisterFromCombine(courseplayer, self)
 					end
 					if courseplayer.cp.lastActiveCombine and courseplayer.cp.lastActiveCombine == self then
+						courseplay:removeFromVehicleLocalIgnoreList(self, courseplayer.cp.lastActiveCombine)
 						courseplayer.cp.lastActiveCombine = nil
 					end
 				end

--- a/settings.lua
+++ b/settings.lua
@@ -675,6 +675,7 @@ function courseplay:removeActiveCombineFromTractor(vehicle)
 	if vehicle.cp.activeCombine ~= nil then
 		courseplay:unregisterFromCombine(vehicle, vehicle.cp.activeCombine);
 	end;
+	courseplay:removeFromVehicleLocalIgnoreList(vehicle, vehicle.cp.lastActiveCombine)
 	vehicle.cp.lastActiveCombine = nil;
 	courseplay.hud:setReloadPageOrder(vehicle, 4, true);
 end;

--- a/start_stop.lua
+++ b/start_stop.lua
@@ -715,7 +715,9 @@ function courseplay:stop(self)
 	if self.cp.takeOverSteering then
 		self.cp.takeOverSteering = false
 	end
-	
+
+	courseplay:removeFromVehicleLocalIgnoreList(vehicle, self.cp.activeCombine)
+	courseplay:removeFromVehicleLocalIgnoreList(vehicle, self.cp.lastActiveCombine)
 	courseplay:releaseCombineStop(self)
 	self.cp.BunkerSiloMap = nil
 	self.cp.mode9TargetSilo = nil

--- a/traffic.lua
+++ b/traffic.lua
@@ -172,7 +172,11 @@ function courseplay:updateCollisionVehicle(vehicle)
 	 courseplay:debug(string.format("    setting vehicle.cp.collidingVehicleId to %d (%s)",currentCollisionVehicleId,tostring(getName(currentCollisionVehicleId))), 3);	
 	end
 	vehicle.cp.collidingVehicleId = currentCollisionVehicleId
-
+	if vehicle.cp.collidingVehicleId ~= nil then
+		courseplay.debugVehicle(3, vehicle, 'updateCollisionVehicle: vehicle.cp.collidingVehicleId = %d (%s)',vehicle.cp.collidingVehicleId, getName(vehicle.cp.collidingVehicleId))
+	else
+		courseplay.debugVehicle(3, vehicle, 'updateCollisionVehicle: vehicle.cp.collidingVehicleId is nil')
+	end;
 end
 
 function courseplay:checkTraffic(vehicle, displayWarnings, allowedToDrive)
@@ -337,7 +341,7 @@ function courseplay:removeLegacyCollisionTriggers(vehicle)
 	return ret;
 end
 
-function courseplay:setTrafficCollisionOnField(vehicle, lx, lz, disableLongCheck)
+function courseplay:setTrafficCollisionOnField(vehicle, lx, lz, disableLongCheck, distanceToCombine)
 	local steeringfactor = 0.25;
 	local colDirX = lx;
 	local colDirZ = lz;
@@ -346,7 +350,7 @@ function courseplay:setTrafficCollisionOnField(vehicle, lx, lz, disableLongCheck
 		courseplay:setCollisionDirection(vehicle.cp.DirectionNode, vehicle.cp.trafficCollisionTriggers[1], colDirX * steeringfactor, colDirZ * steeringfactor);
 		local recordNumber = vehicle.cp.waypointIndex
 		for i=2,vehicle.cp.numTrafficCollisionTriggers do	-- continue with i=2 for the rest of the colli boxes
-			if disableLongCheck or recordNumber + i >= vehicle.cp.numWaypoints then
+			if disableLongCheck or (distanceToCombine) < ((i+2) * 5) then
 				courseplay:setCollisionDirection(vehicle.cp.trafficCollisionTriggers[i-1], vehicle.cp.trafficCollisionTriggers[i], 0, -1);
 			else
 				courseplay:setCollisionDirection(vehicle.cp.trafficCollisionTriggers[i-1], vehicle.cp.trafficCollisionTriggers[i], 0, 1);

--- a/vehicles.lua
+++ b/vehicles.lua
@@ -1559,3 +1559,47 @@ function courseplay:findAiCollisionTrigger(vehicle)
 
 	return ret;
 end
+
+--[[
+remove the targetVehicle and all its components and attached implements to the local collision ignore list of the vehicle
+]]
+function courseplay:removeFromVehicleLocalIgnoreList(vehicle, targetVehicle)
+	if vehicle and targetVehicle and vehicle.cpTrafficCollisionIgnoreList then
+
+		vehicle.cpTrafficCollisionIgnoreList[targetVehicle.rootNode] = nil;
+
+		-- TRAFFIC COLLISION IGNORE LIST (components)
+		if targetVehicle.components ~= nil then
+			courseplay:debug(('%s: removing %q (%q) components to cpTrafficCollisionIgnoreList'):format(nameNum(vehicle), nameNum(targetVehicle), tostring(targetVehicle.cp.xmlFileName)), 3);
+			for i,component in pairs(targetVehicle.components) do
+				vehicle.cpTrafficCollisionIgnoreList[component.node] = nil;
+			end;
+		end;
+		-- CHECK ATTACHED IMPLEMENTS
+		for k,impl in pairs(targetVehicle:getAttachedImplements()) do
+			courseplay:removeFromVehicleLocalIgnoreList(vehicle, impl.object);
+		end;
+	end;
+end
+
+--[[
+add the targetVehicle and all its components and attached implements to the local collision ignore list of the vehicle
+]]
+function courseplay:addToVehicleLocalIgnoreList(vehicle, targetVehicle)
+	if vehicle and targetVehicle and vehicle.cpTrafficCollisionIgnoreList then
+
+		vehicle.cpTrafficCollisionIgnoreList[targetVehicle.rootNode] = true;
+
+		-- TRAFFIC COLLISION IGNORE LIST (components)
+		if targetVehicle.components ~= nil then
+			courseplay:debug(('%s: adding %q (%q) components to cpTrafficCollisionIgnoreList'):format(nameNum(vehicle), nameNum(targetVehicle), tostring(targetVehicle.cp.xmlFileName)), 3);
+			for i,component in pairs(targetVehicle.components) do
+				vehicle.cpTrafficCollisionIgnoreList[component.node] = true;
+			end;
+		end;
+		-- CHECK ATTACHED IMPLEMENTS
+		for k,impl in pairs(targetVehicle:getAttachedImplements()) do
+			courseplay:addToVehicleLocalIgnoreList(vehicle, impl.object);
+		end;
+	end;
+end


### PR DESCRIPTION
1. Adapt the collision detection to the distance to the combine to avoid detecting a collission of combine objects like a "very small" back axis (!) when the tractor is approaching - snake folding
2. Assign the tractor the combine it is working with as an ignored local object