### PR TITLE
Bugfix 4017

### DIFF
--- a/start_stop.lua
+++ b/start_stop.lua
@@ -63,6 +63,9 @@ function courseplay:start(self)
 	self.cpTrafficCollisionIgnoreList = {}
 	-- self.CPnumCollidingVehicles = 0;					-- ??? not used anywhere
 	self.cp.collidingVehicleId = nil
+	self.cp.collidingObjects = {
+		all = {};
+	};
 	
 	courseplay:debug(string.format("%s: Start/Stop: deleting \"self.cp.collidingVehicleId\"", nameNum(self)), 3);
 	--self.numToolsCollidingVehicles = {};
@@ -744,6 +747,9 @@ function courseplay:stop(self)
 	self.cp.TrafficBrake = false
 	self.cp.inTraffic = false
 	self.cp.collidingVehicleId = nil
+	self.cp.collidingObjects = {
+		all = {};
+	};
 	self.cp.bypassWaypointsSet = false
 	-- deactivate beacon and hazard lights
 	if self.beaconLightsActive then

--- a/traffic.lua
+++ b/traffic.lua
@@ -189,7 +189,7 @@ function courseplay:checkTraffic(vehicle, displayWarnings, allowedToDrive)
 		local x, y, z = getWorldTranslation(vehicle.cp.DirectionNode);
 		local halfLength =  (collisionVehicle.sizeLength or 5) * 0.5;
 		local x1,z1 = AIVehicleUtil.getDriveDirection(vehicle.cp.collidingVehicleId, x, y, z);
-		if z1 > -0.9 then -- tractor in front of vehicle face2face or beside < 4 o'clock
+		if z1 > -0.9 and abs(z1) < 15 and abs(x1) < 15 then -- tractor in front of vehicle face2face or beside < 4 o'clock
 			ahead = true
 		end;
 		local _,transY,_ = getTranslation(vehicle.cp.collidingVehicleId);


### PR DESCRIPTION
Problem: see #4017
Root cause: table with collision objects not cleared on start / stop of CP.
Solution: clear collision objects on start and stop of CP
additional: enhance traffic ahead detection