### PR TITLE
Blind fix attempt for #4506

### DIFF
--- a/AIDriver.lua
+++ b/AIDriver.lua
@@ -1183,9 +1183,11 @@ end
 function AIDriver:getHasAllTippersClosed()
 	local allClosed = true
 	for _, tipper in pairs (self.vehicle.cp.workTools) do
-		if tipper.spec_dischargeable ~= nil and tipper:getTipState() ~= Trailer.TIPSTATE_CLOSED then
-			allClosed = false
-		end
+    if courseplay:isTrailer(tipper) then
+      if tipper.spec_dischargeable ~= nil and tipper:getTipState() ~= Trailer.TIPSTATE_CLOSED then
+        allClosed = false
+      end
+    end
 
 	end
 	return allClosed

--- a/toolManager.lua
+++ b/toolManager.lua
@@ -250,6 +250,9 @@ function courseplay:hasBunkerSiloCompacter(workTool)
 		return true
 	end
 end
+function courseplay:isTrailer(workTool)
+	return workTool.typeName:match("trailer");
+end;
 
 -- UPDATE WORKTOOL DATA
 function courseplay:updateWorkTools(vehicle, workTool, isImplement)


### PR DESCRIPTION
AiDriver should only check tip state if the tool is actually a trailer <vehicle type="trailer">.