### PR TITLE
Call AutoDrive to refuel (#4889)

### DIFF
--- a/AIDriver.lua
+++ b/AIDriver.lua
@@ -525,7 +525,7 @@ function AIDriver:onEndCourse()
 			courseplay:stop(self.vehicle)
 			-- TODO: encapsulate this in an AutoDriveInterface class
 			local parkDestination = self.vehicle.spec_autodrive:GetParkDestination(self.vehicle)
-			self.vehicle.spec_autodrive:StartDrivingWithPathFinder(self.vehicle, parkDestination, 0, nil, nil, nil)
+			self.vehicle.spec_autodrive:StartDrivingWithPathFinder(self.vehicle, parkDestination, -3, nil, nil, nil)
 		end
 	elseif self.vehicle.cp.stopAtEnd then
 		if self.state ~= self.states.STOPPED then

--- a/settings.lua
+++ b/settings.lua
@@ -2190,10 +2190,14 @@ function AutoDriveModeSetting:init(vehicle)
 		{
 			AutoDriveModeSetting.DONT_USE,
 			AutoDriveModeSetting.UNLOAD_OR_REFILL,
+			AutoDriveModeSetting.PARK,
+			AutoDriveModeSetting.UNLOAD_OR_REFILL_PARK,
 		},
 		{
 			'COURSEPLAY_AUTODRIVE_DONT_USE',
 			'COURSEPLAY_AUTODRIVE_UNLOAD_OR_REFILL',
+			'COURSEPLAY_AUTODRIVE_PARK',
+			'COURSEPLAY_AUTODRIVE_UNLOAD_OR_REFILL_PARK',
 		})
 	self:update()
 end


### PR DESCRIPTION
Only if unload or refill with AD is active.
Also fixed not loading saved setting for use autodrive if it was park or refill and park.
Needs new AD update (already created pull request by me) but keeps compatibility with previous versions, just doesn´t exit field with pathfinding if AD not updated