### PR TITLE
fix für #4534

### DIFF
--- a/AIDriver.lua
+++ b/AIDriver.lua
@@ -922,9 +922,11 @@ function AIDriver:dischargeAtUnloadPoint(dt,unloadPointIx)
 				
 				--ready with tipping, go forward on the course
 				if tipper.cp.fillLevel == 0 then
-					self.ppc:initialize(self.course:getNextFwdWaypointIx(self.ppc:getCurrentWaypointIx()));
 					tipper:setDischargeState(Dischargeable.DISCHARGE_STATE_OFF)
 					self.pullForward = nil
+					if self:getHasAllTippersClosed()then
+						self.ppc:initialize(self.course:getNextFwdWaypointIx(self.ppc:getCurrentWaypointIx()));
+					end
 				end
 				
 				--do the driving here because if we initalize the ppc, we dont have the unload point anymore

--- a/AIDriver.lua
+++ b/AIDriver.lua
@@ -1063,7 +1063,7 @@ function AIDriver:tipIntoBGASiloTipTrigger(dt)
 				end
 				
 				local tipState = tipper:getTipState()
-				if tipState == Trailer.TIPSTATE_CLOSED or tipState == Trailer.TIPSTATE_CLOSING then
+				if tipper.cp.fillLevel > 0 and (tipState == Trailer.TIPSTATE_CLOSED or tipState == Trailer.TIPSTATE_CLOSING) then
 					courseplay.debugVehicle(2,self.vehicle,"start tipping")
 					tipper:setDischargeState(Dischargeable.DISCHARGE_STATE_GROUND)
 				end				


### PR DESCRIPTION
Hallo @Tensuko 
Ich hab mich mal mit Abladen in ein BGA Silo beschäftigt, da er hier mit offenem Trailer weitergefahren ist. #4534
Beim Rückwärts abladen in ein Silo habe ich eingetragen, das er erst losfahren soll wenn alle "Tippers" geschlossen sind.

Bei einem normalen Durchfahrsilo hat er am ende des Silos versucht nochmal abzuladen, weshalb sich er Trailer nicht geschlossen hat. Deswegen hab ich hier noch eingetragen das er nur abladen soll wenn der Füllstand >0 ist. 

Gruß Henne