### PR TITLE
Open combine pipe when waiting to unload.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 out
 reload/venv
 reload.xml
+.vscode
 
 
 # Windows image file caches

--- a/CombineAIDriver.lua
+++ b/CombineAIDriver.lua
@@ -719,7 +719,7 @@ function CombineAIDriver:handleCombinePipe()
 end
 
 function CombineAIDriver:shouldCombineOpenPipeWhileWaitingForUnload()
-	return self.vehicle.cp.stopWhenUnloading and self:isWaitingForUnload()
+	return self.vehicle.cp.openPipeWhenWaiting and self:isWaitingForUnload()
 end
 
 --- Support for AutoDrive mod: they'll only find us if we open the pipe

--- a/CombineAIDriver.lua
+++ b/CombineAIDriver.lua
@@ -711,13 +711,16 @@ function CombineAIDriver:handlePipe()
 end
 
 function CombineAIDriver:handleCombinePipe()
-	if self:isFillableTrailerUnderPipe() or self:isAutoDriveWaitingForPipe() or self:isWaitingForUnload() then
+	if self:isFillableTrailerUnderPipe() or self:isAutoDriveWaitingForPipe() or self:shouldCombineOpenPipeWhileWaitingForUnload() then
 		self:openPipe()
 	else
 		self:closePipe()
 	end
 end
 
+function CombineAIDriver:shouldCombineOpenPipeWhileWaitingForUnload()
+	return self.vehicle.cp.stopWhenUnloading and self:isWaitingForUnload()
+end
 
 --- Support for AutoDrive mod: they'll only find us if we open the pipe
 function CombineAIDriver:isAutoDriveWaitingForPipe()

--- a/CombineAIDriver.lua
+++ b/CombineAIDriver.lua
@@ -711,7 +711,7 @@ function CombineAIDriver:handlePipe()
 end
 
 function CombineAIDriver:handleCombinePipe()
-	if self:isFillableTrailerUnderPipe() or self:isAutoDriveWaitingForPipe() then
+	if self:isFillableTrailerUnderPipe() or self:isAutoDriveWaitingForPipe() or self:isWaitingForUnload() then
 		self:openPipe()
 	else
 		self:closePipe()

--- a/base.lua
+++ b/base.lua
@@ -41,6 +41,7 @@ function courseplay:onLoad(savegame)
 	end
 	self.cp.speedDebugLine = "no speed info"
 	self.cp.stopWhenUnloading = false;
+	self.cp.openPipeWhenWaiting = false;
 
 	-- GIANT DLC
 	self.cp.haveInversedRidgeMarkerState = nil; --bool
@@ -1629,6 +1630,7 @@ function courseplay:loadVehicleCPSettings(xmlFile, key, resetVehicles)
 			curKey = key .. '.courseplay.combine';
 			self.cp.driverPriorityUseFillLevel = Utils.getNoNil(getXMLBool(xmlFile, curKey .. '#driverPriorityUseFillLevel'), false);
 			self.cp.stopWhenUnloading = Utils.getNoNil(getXMLBool(xmlFile, curKey .. '#stopWhenUnloading'), false);
+			self.cp.openPipeWhenWaiting = Utils.getNoNil(getXMLBool(xmlFile, curKey .. '#openPipeWhenWaiting'), false);
 		end;
 
 		--overLoaderPipe
@@ -1817,6 +1819,7 @@ function courseplay:saveToXMLFile(xmlFile, key, usedModNames)
 	if self.cp.isCombine then
 		setXMLBool(xmlFile, newKey..".combine #driverPriorityUseFillLevel", self.cp.driverPriorityUseFillLevel)
 		setXMLBool(xmlFile, newKey..".combine #stopWhenUnloading", self.cp.stopWhenUnloading)
+		setXMLBool(xmlFile, newKey..".combine #openPipeWhenWaiting", self.cp.openPipeWhenWaiting)
 	end;
 
 	self.cp.settings:saveToXML(xmlFile, newKey)

--- a/hud.lua
+++ b/hud.lua
@@ -1174,8 +1174,11 @@ function courseplay.hud:updatePageContent(vehicle, page)
 				elseif entry.functionToCall == 'toggleStopWhenUnloading' then
 					vehicle.cp.hud.content.pages[page][line][1].text = courseplay:loc('COURSEPLAY_STOP_DURING_UNLOADING');
 					vehicle.cp.hud.content.pages[page][line][2].text = vehicle.cp.stopWhenUnloading and courseplay:loc('COURSEPLAY_ACTIVATED') or courseplay:loc('COURSEPLAY_DEACTIVATED');
-		
-		
+
+				elseif entry.functionToCall == 'toggleOpenPipeWhenWaiting' then
+					vehicle.cp.hud.content.pages[page][line][1].text = courseplay:loc('COURSEPLAY_OPEN_PIPE_WHEN_WAITING');
+					vehicle.cp.hud.content.pages[page][line][2].text = vehicle.cp.openPipeWhenWaiting and courseplay:loc('COURSEPLAY_ACTIVATED') or courseplay:loc('COURSEPLAY_DEACTIVATED');
+
 				elseif entry.functionToCall == 'changeHeadlandReverseManeuverType' then
 					vehicle.cp.hud.content.pages[page][line][1].text = courseplay:loc('COURSEPLAY_HEADLAND_REVERSE_MANEUVER_TYPE')
 					vehicle.cp.hud.content.pages[page][line][2].text = courseplay:loc( courseplay.headlandReverseManeuverTypeText[ vehicle.cp.headland.reverseManeuverType ])
@@ -2440,7 +2443,8 @@ function courseplay.hud:setCombineAIDriverContent(vehicle)
 	else
 		self:addRowButton(vehicle,'toggleDriverPriority', 0, 4, 1 )
 		self:addRowButton(vehicle,'toggleStopWhenUnloading', 0, 5, 1 )
-		self:addRowButton(vehicle,'changeHeadlandReverseManeuverType', 0, 6, 1 )
+		self:addRowButton(vehicle,'toggleOpenPipeWhenWaiting', 0, 6, 1 )
+		self:addRowButton(vehicle,'changeHeadlandReverseManeuverType', 0, 7, 1 )
 	end
 	self:setReloadPageOrder(vehicle, -1, true)
 end

--- a/settings.lua
+++ b/settings.lua
@@ -1397,6 +1397,15 @@ function courseplay:toggleStopWhenUnloading(combine)
 	combine.cp.stopWhenUnloading = not combine.cp.stopWhenUnloading;
 end;
 
+function courseplay:toggleOpenPipeWhenWaiting(combine)
+	if combine.cp.isChopper then
+		combine.cp.openPipeWhenWaiting = false;
+		return;
+	end;
+	if combine.cp.openPipeWhenWaiting == nil then combine.cp.openPipeWhenWaiting = false; end;
+	combine.cp.openPipeWhenWaiting = not combine.cp.openPipeWhenWaiting;
+end;
+
 function courseplay:goToVehicle(curVehicle, targetVehicle)
 	-- print(string.format("%s: goToVehicle(): targetVehicle=%q", nameNum(curVehicle), nameNum(targetVehicle)));
 	g_client:getServerConnection():sendEvent(VehicleEnterRequestEvent:new(targetVehicle, g_currentMission.missionInfo.playerStyle, g_currentMission.player.ownerFarmId));

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -296,6 +296,7 @@
 		<text name="COURSEPLAY_COVER_HANDLING" 								text="Cobertura" />
 		<text name="COURSEPLAY_REMOVEACTIVECOMBINEFROMTRACTOR" 				text="Remover designação da ceifadeira" />
 		<text name="COURSEPLAY_STOP_DURING_UNLOADING" 						text="Parar durante descarregamento" />
+		<text name="COURSEPLAY_OPEN_PIPE_WHEN_WAITING" 						text="Tubo aberto ao aguardar descarregamento" />
 		<text name="COURSEPLAY_SLIPPING_WARNING" 							text="está patinando" />
 		<text name="COURSEPLAY_REFILL_UNTIL_PCT" 							text="Encher até" />
 		<text name="COURSEPLAY_BGA_IS_FULL" 								text=": Silo está cheio!" />

--- a/translations/translation_cs.xml
+++ b/translations/translation_cs.xml
@@ -289,6 +289,7 @@
 		<text name="COURSEPLAY_COVER_HANDLING" 								text="拖斗盖子" />
 		<text name="COURSEPLAY_REMOVEACTIVECOMBINEFROMTRACTOR" 				text="删除指定的收割机" />
 		<text name="COURSEPLAY_STOP_DURING_UNLOADING" 						text="卸载时停车" />
+		<text name="COURSEPLAY_OPEN_PIPE_WHEN_WAITING" 						text="等待卸载时打开管道" />
 		<text name="COURSEPLAY_SLIPPING_WARNING" 							text="车辆打滑！" />
 		<text name="COURSEPLAY_REFILL_UNTIL_PCT" 							text="重新填充:" />
 		<text name="COURSEPLAY_BGA_IS_FULL" 								text=":青贮池已满!" />

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -295,6 +295,7 @@
 		<text name="COURSEPLAY_COVER_HANDLING" 								text="Plachta/Kryt vleku:" />
 		<text name="COURSEPLAY_REMOVEACTIVECOMBINEFROMTRACTOR" 				text="Odstraň přiřezení ke kombajnu" />
 		<text name="COURSEPLAY_STOP_DURING_UNLOADING" 						text="Zastavit při vykládání:" />
+		<text name="COURSEPLAY_OPEN_PIPE_WHEN_WAITING" 						text="Při čekání na vyložení otevřete potrubí" />
 		<text name="COURSEPLAY_SLIPPING_WARNING" 							text="se zasekl" />
 		<text name="COURSEPLAY_REFILL_UNTIL_PCT" 							text="Naplnit do:" />
 		<text name="COURSEPLAY_BGA_IS_FULL" 								text=": Bunker je plný!" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -295,6 +295,7 @@
 		<text name="COURSEPLAY_COVER_HANDLING" 								text="Planen" />
 		<text name="COURSEPLAY_REMOVEACTIVECOMBINEFROMTRACTOR" 				text="Drescher-Zuordnung entfernen" />
 		<text name="COURSEPLAY_STOP_DURING_UNLOADING" 						text="Während dem Abladen anhalten" />
+		<text name="COURSEPLAY_OPEN_PIPE_WHEN_WAITING" 						text="Öffnen Sie das Rohr, wenn Sie auf das Entladen warten" />
 		<text name="COURSEPLAY_SLIPPING_WARNING" 							text=": durchdrehende Reifen" />
 		<text name="COURSEPLAY_REFILL_UNTIL_PCT" 							text="Auffüllen bis:" />
 		<text name="COURSEPLAY_BGA_IS_FULL" 								text=": Bunkersilo ist voll!" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -295,6 +295,7 @@
 		<text name="COURSEPLAY_COVER_HANDLING" 								text="Covers" />
 		<text name="COURSEPLAY_REMOVEACTIVECOMBINEFROMTRACTOR" 				text="Remove combine assignment" />
 		<text name="COURSEPLAY_STOP_DURING_UNLOADING" 						text="Stop during unloading" />
+		<text name="COURSEPLAY_OPEN_PIPE_WHEN_WAITING" 						text="Open pipe when waiting for unload" />
 		<text name="COURSEPLAY_SLIPPING_WARNING" 							text="is slipping" />
 		<text name="COURSEPLAY_REFILL_UNTIL_PCT" 							text="Refill until:" />
 		<text name="COURSEPLAY_BGA_IS_FULL" 								text=": Bunker silo is full!" />

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -291,6 +291,7 @@
 		<text name="COURSEPLAY_COVER_HANDLING" 								text="Lonas" />
 		<text name="COURSEPLAY_REMOVEACTIVECOMBINEFROMTRACTOR" 				text="Cancelar la asignación a esta cosechadora" />
 		<text name="COURSEPLAY_STOP_DURING_UNLOADING" 						text="Detenerse durante la descarga" />
+		<text name="COURSEPLAY_OPEN_PIPE_WHEN_WAITING" 						text="Abra la tubería al esperar la descarga" />
 		<text name="COURSEPLAY_SLIPPING_WARNING" 							text="no puede continuar" />
 		<text name="COURSEPLAY_REFILL_UNTIL_PCT" 							text="Llenar hasta:" />
 		<text name="COURSEPLAY_BGA_IS_FULL" 								text=": el silo ésta lleno!" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -295,6 +295,7 @@
     <text name="COURSEPLAY_COVER_HANDLING" 						 		text="Bâche" />
     <text name="COURSEPLAY_REMOVEACTIVECOMBINEFROMTRACTOR" 				text="Retirer l'affectation à cette batteuse" />
     <text name="COURSEPLAY_STOP_DURING_UNLOADING" 						text="Arrêter pendant le déchargement" />
+    <text name="COURSEPLAY_OPEN_PIPE_WHEN_WAITING" 						text="Ouvrir le tuyau en attendant le déchargement" />
     <text name="COURSEPLAY_SLIPPING_WARNING" 					 		text="patine" />
     <text name="COURSEPLAY_REFILL_UNTIL_PCT" 					 		text="Remplir jusqu'à:" />
     <text name="COURSEPLAY_BGA_IS_FULL" 						 		text=": le silo est plein!" />

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -291,6 +291,7 @@
 		<text name="COURSEPLAY_COVER_HANDLING" 								text="Ponyva:" />
 		<text name="COURSEPLAY_REMOVEACTIVECOMBINEFROMTRACTOR" 				text="Kombájnkijelölés eltávolítása" />
 		<text name="COURSEPLAY_STOP_DURING_UNLOADING" 						text="Kirakodás közben leállít" />
+		<text name="COURSEPLAY_OPEN_PIPE_WHEN_WAITING" 						text="Nyissa ki a csövet, amikor kirakodásra vár" />
 		<text name="COURSEPLAY_SLIPPING_WARNING" 							text="kipörög" />
 		<text name="COURSEPLAY_REFILL_UNTIL_PCT" 							text="Újratölteni:" />
 		<text name="COURSEPLAY_BGA_IS_FULL" 								text=": a BGA siló tele van!" />

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -295,6 +295,7 @@
 		<text name="COURSEPLAY_COVER_HANDLING" 								text="Copertura" />
 		<text name="COURSEPLAY_REMOVEACTIVECOMBINEFROMTRACTOR" 				text="Rimuovere assegnazione trebbia" />
 		<text name="COURSEPLAY_STOP_DURING_UNLOADING" 						text="Fermarsi durante lo scarico" />
+		<text name="COURSEPLAY_OPEN_PIPE_WHEN_WAITING" 						text="Aprire il tubo in attesa di scarico" />
 		<text name="COURSEPLAY_SLIPPING_WARNING" 							text="sta slittando" />
 		<text name="COURSEPLAY_REFILL_UNTIL_PCT" 							text="Riempire rimorchio fino al:" />
 		<text name="COURSEPLAY_BGA_IS_FULL" 								text=": il silo è pieno!" />

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -295,6 +295,7 @@
 		<text name="COURSEPLAY_COVER_HANDLING" 								text="カバー" />
 		<text name="COURSEPLAY_REMOVEACTIVECOMBINEFROMTRACTOR" 				text="コンバインの割り当てを解除" />
 		<text name="COURSEPLAY_STOP_DURING_UNLOADING" 						text="アンロード時に停止" />
+		<text name="COURSEPLAY_OPEN_PIPE_WHEN_WAITING" 						text="アンロードを待つときにパイプを開く" />
 		<text name="COURSEPLAY_SLIPPING_WARNING" 							text="スタック中" />
 		<text name="COURSEPLAY_REFILL_UNTIL_PCT" 							text="補給まで:" />
 		<text name="COURSEPLAY_BGA_IS_FULL" 								text=": バンカーサイロがいっぱいです!" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -291,6 +291,7 @@
 		<text name="COURSEPLAY_COVER_HANDLING" 								text="Zeilen" />
 		<text name="COURSEPLAY_REMOVEACTIVECOMBINEFROMTRACTOR" 				text="Verwijder combine opdracht" />
 		<text name="COURSEPLAY_STOP_DURING_UNLOADING" 						text="Stop tijdens lossen" />
+		<text name="COURSEPLAY_OPEN_PIPE_WHEN_WAITING" 						text="Open de buis tijdens het wachten op lossen" />
 		<text name="COURSEPLAY_SLIPPING_WARNING" 							text="Slippend" />
 		<text name="COURSEPLAY_REFILL_UNTIL_PCT" 							text="Bijvullen tot:" />
 		<text name="COURSEPLAY_BGA_IS_FULL" 								text=": Bunker silo is vol!" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -295,6 +295,7 @@
 		<text name="COURSEPLAY_COVER_HANDLING"							 	text="Plandeka:" />
 		<text name="COURSEPLAY_REMOVEACTIVECOMBINEFROMTRACTOR"			 	text="Usuń zadanie kombajnu" />
 		<text name="COURSEPLAY_STOP_DURING_UNLOADING"			 		 	text="Zatrzymaj podczas rozładunku" />
+		<text name="COURSEPLAY_OPEN_PIPE_WHEN_WAITING" 						text="Otwórz rurę podczas oczekiwania na rozładunek" />
 		<text name="COURSEPLAY_SLIPPING_WARNING"						 	text="ślizga się" />
 		<text name="COURSEPLAY_REFILL_UNTIL_PCT"						 	text="Uzupełnij do:" />
 		<text name="COURSEPLAY_BGA_IS_FULL"								 	text=": Silos bunkrowy jest pełny!" />

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -291,6 +291,7 @@
 		<text name="COURSEPLAY_COVER_HANDLING" 						 		text="cobertura" />
 		<text name="COURSEPLAY_REMOVEACTIVECOMBINEFROMTRACTOR" 				text="Remover definições da ceifeira" />
 		<text name="COURSEPLAY_STOP_DURING_UNLOADING" 						text="Parar durante a descarga" />
+		<text name="COURSEPLAY_OPEN_PIPE_WHEN_WAITING" 						text="Tubo aberto ao aguardar descarregamento" />
 		<text name="COURSEPLAY_SLIPPING_WARNING" 					 		text="a patinar" />
 		<text name="COURSEPLAY_REFILL_UNTIL_PCT" 					 		text="Encher até" />
 		<text name="COURSEPLAY_BGA_IS_FULL" 						 		text=": Silo BGA está cheio!" />

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -295,6 +295,7 @@
 		<text name="COURSEPLAY_COVER_HANDLING" 								text="Тент:" />
 		<text name="COURSEPLAY_REMOVEACTIVECOMBINEFROMTRACTOR" 				text="Удалить комбайн из списка" />
 		<text name="COURSEPLAY_STOP_DURING_UNLOADING" 						text="Стоять при разгрузке:" />
+		<text name="COURSEPLAY_OPEN_PIPE_WHEN_WAITING" 						text="Открытая труба в ожидании разгрузки" />
 		<text name="COURSEPLAY_SLIPPING_WARNING" 							text="забуксовал." />
 		<text name="COURSEPLAY_REFILL_UNTIL_PCT" 							text="Наполнять до:" />
 		<text name="COURSEPLAY_BGA_IS_FULL" 								text=": силосная яма заполнена!" />

--- a/translations/translation_sl.xml
+++ b/translations/translation_sl.xml
@@ -295,6 +295,7 @@
 		<text name="COURSEPLAY_COVER_HANDLING" 								text="Prevleke" />
 		<text name="COURSEPLAY_REMOVEACTIVECOMBINEFROMTRACTOR" 				text="Odstrani dodelitev kombajna" />
 		<text name="COURSEPLAY_STOP_DURING_UNLOADING" 						text="UStavi med odlaganjem" />
+		<text name="COURSEPLAY_OPEN_PIPE_WHEN_WAITING" 						text="Med čakanjem na razkladanje odprite cev" />
 		<text name="COURSEPLAY_SLIPPING_WARNING" 							text="zdrsava" />
 		<text name="COURSEPLAY_REFILL_UNTIL_PCT" 							text="Napolni do:" />
 		<text name="COURSEPLAY_BGA_IS_FULL" 								text=": Koritast silos je poln!" />


### PR DESCRIPTION
I like this suggestion #4252 . Specifically when driving the chaser cart yourself vs using CP.  To that end, I made a simple change to put the pipe out when combines are sitting on the field waiting to unload.
I've been playing with it for a couple days and it works exactly how I want as a user.
I know there was discussion in the referenced issue about making it configurable. I can certainly work on making a HUD change to accommodate a new setting, but I thought I'd start with this. For me, I don't see a reason to make it configurable, but I am here to learn. It mimics the way the built-in Helpers work also.