### PR TITLE
Fixed fuel save option on Mode 1

### DIFF
--- a/GrainTransportAIDriver.lua
+++ b/GrainTransportAIDriver.lua
@@ -92,7 +92,6 @@ function GrainTransportAIDriver:drive(dt)
 		-- we drive the course as usual
 		self:driveCourse(dt)
 	end
-	self:resetSpeed()
 end
 
 function GrainTransportAIDriver:onWaypointChange(newIx)


### PR DESCRIPTION
#3933 
Removed 'resetSpeed' from GrainTransportAIDriver.