### PR TITLE
Fixed issue with tip triggers not being registered correctly in multiplayer

### DIFF
--- a/AIDriver.lua
+++ b/AIDriver.lua
@@ -1222,8 +1222,9 @@ function AIDriver:tipTriggerIsFull(trigger,tipper)
 	local trigger = self.vehicle.cp.currentTipTrigger
 	local trailerFillType = tipper.cp.fillType
 	if trigger and trigger.unloadingStation then
-		local fillLevel = trigger.unloadingStation:getFillLevel(trailerFillType,1)
-		local capacity = trigger.unloadingStation:getCapacity(trailerFillType,1)
+		local ownerFarmId = self.vehicle.getOwnerFarmId(self.vehicle);
+		local fillLevel = trigger.unloadingStation:getFillLevel(trailerFillType, ownerFarmId);
+		local capacity = trigger.unloadingStation:getCapacity(trailerFillType, ownerFarmId);
 		courseplay.debugVehicle(2,self.vehicle,'    trigger (%s) fillLevel=%d, capacity=%d ',tostring(trigger.triggerId), fillLevel, capacity);
 		if fillLevel>=capacity then
 			courseplay.debugVehicle(2, self.vehicle,'    trigger (%s) Trigger is full',tostring(triggerId));

--- a/triggers.lua
+++ b/triggers.lua
@@ -130,8 +130,9 @@ function courseplay:findTipTriggerCallback(transformId, x, y, z, distance)
 					courseplay:debug(('    trigger (%s) accepts trailerFillType'):format(tostring(triggerId)), 1);
 					-- check trigger fillLevel / capacity
 					if trigger.unloadingStation then
-						local fillLevel = trigger.unloadingStation:getFillLevel(trailerFillType,1)
-						local capacity = trigger.unloadingStation:getCapacity(trailerFillType,1)
+						local ownerFarmId = self:getOwnerFarmId();
+						local fillLevel = trigger.unloadingStation:getFillLevel(trailerFillType, ownerFarmId);
+						local capacity = trigger.unloadingStation:getCapacity(trailerFillType, ownerFarmId);
 						courseplay:debug(('    trigger (%s) fillLevel=%d, capacity=%d '):format(tostring(triggerId), fillLevel, capacity), 1);
 						if fillLevel>=capacity then
 							courseplay:debug(('    trigger (%s) Trigger is full -> abort'):format(tostring(triggerId)), 1);


### PR DESCRIPTION
Found an issue where the tip trigger was not detecting the available capacity of a silo so would never trigger a tip. Only occurs in multiplayer with multiple farms.