### PR TITLE
Fixed issue with load triggers not activating when running multiplayer

### DIFF
--- a/base.lua
+++ b/base.lua
@@ -1870,17 +1870,35 @@ LoadTrigger.getIsActivatable = Utils.overwrittenFunction(LoadTrigger.getIsActiva
 
 -- LoadTrigger doesn't allow filling non controlled tools
 function courseplay:onActivateObject(superFunc,vehicle)
-	if vehicle~= nil then
-		--if i'm in the vehicle, all is good and I can use the normal function, if not, i have to cheat:
-		if g_currentMission.controlledVehicle ~= vehicle then
-			local oldControlledVehicle = g_currentMission.controlledVehicle;
-			g_currentMission.controlledVehicle = vehicle;
-			superFunc(self);
-			g_currentMission.controlledVehicle = oldControlledVehicle;
-			return;
-		end
+	--No vehicle, non-courseplay call so just call default version
+	if vehicle == nil then
+		superFunc(self);
+		return;
 	end
+	--Vehicle present, called from courseplay
+	--Cache giant values to restore later
+	local defaultGetFarmIdFunction = g_currentMission.getFarmId;
+	local oldControlledVehicle = g_currentMission.controlledVehicle;
+
+	--Override farm id to match the calling vehicle (fixes issue when obtaining fill levels)
+	local overriddenFarmIdFunc = function()
+		local ownerFarmId = vehicle:getOwnerFarmId()
+		courseplay:debug(string.format('Overriding farm id during loading to %d', ownerFarmId), 19);
+		return ownerFarmId;
+	end
+	g_currentMission.getFarmId = overriddenFarmIdFunc;
+
+	--Override controlled vehicle if I'm not in it
+	if g_currentMission.controlledVehicle ~= vehicle then
+		g_currentMission.controlledVehicle = vehicle;
+	end
+
+	--Call giant method with new params set
 	superFunc(self);
+	
+	--Restore previous values
+	g_currentMission.getFarmId = defaultGetFarmIdFunction;
+	g_currentMission.controlledVehicle = oldControlledVehicle;
 end
 LoadTrigger.onActivateObject = Utils.overwrittenFunction(LoadTrigger.onActivateObject,courseplay.onActivateObject)
 

--- a/base.lua
+++ b/base.lua
@@ -1868,40 +1868,6 @@ function courseplay:getIsActivatable(superFunc,objectToFill)
 end
 LoadTrigger.getIsActivatable = Utils.overwrittenFunction(LoadTrigger.getIsActivatable,courseplay.getIsActivatable)
 
--- LoadTrigger doesn't allow filling non controlled tools
-function courseplay:onActivateObject(superFunc,vehicle)
-	--No vehicle, non-courseplay call so just call default version
-	if vehicle == nil then
-		superFunc(self);
-		return;
-	end
-	--Vehicle present, called from courseplay
-	--Cache giant values to restore later
-	local defaultGetFarmIdFunction = g_currentMission.getFarmId;
-	local oldControlledVehicle = g_currentMission.controlledVehicle;
-
-	--Override farm id to match the calling vehicle (fixes issue when obtaining fill levels)
-	local overriddenFarmIdFunc = function()
-		local ownerFarmId = vehicle:getOwnerFarmId()
-		courseplay:debug(string.format('Overriding farm id during loading to %d', ownerFarmId), 19);
-		return ownerFarmId;
-	end
-	g_currentMission.getFarmId = overriddenFarmIdFunc;
-
-	--Override controlled vehicle if I'm not in it
-	if g_currentMission.controlledVehicle ~= vehicle then
-		g_currentMission.controlledVehicle = vehicle;
-	end
-
-	--Call giant method with new params set
-	superFunc(self);
-	
-	--Restore previous values
-	g_currentMission.getFarmId = defaultGetFarmIdFunction;
-	g_currentMission.controlledVehicle = oldControlledVehicle;
-end
-LoadTrigger.onActivateObject = Utils.overwrittenFunction(LoadTrigger.onActivateObject,courseplay.onActivateObject)
-
 -- TODO: make these part of AIDriver
 
 function courseplay:setWaypointIndex(vehicle, number,isRecording)

--- a/toolManager.lua
+++ b/toolManager.lua
@@ -1455,11 +1455,11 @@ function courseplay:setFillOnTrigger(vehicle,workTool,fillOrder,trigger,triggerI
 		--start filling
 		if trigger.onActivateObject then
 			if trigger.autoStart then
-				trigger:onActivateObject(vehicle) 
+				courseplay:activateTriggerForVehicle(trigger, vehicle);
 			elseif not trigger.isLoading then
 				--force Diesel when I'm in fuelFillTrigger or the selected fillType in fillTrigger and start the autoload
 				trigger.autoStart = true
-				trigger:onActivateObject(vehicle) 
+				courseplay:activateTriggerForVehicle(trigger, vehicle);
 				trigger.selectedFillType = (vehicle.cp.fuelFillTrigger and FillType.DIESEL) or (vehicle.cp.siloSelectedFillType ~= FillType.UNKNOWN and vehicle.cp.siloSelectedFillType) or courseplay:getOnlyPossibleFillType(vehicle,workTool,trigger) 
 				g_effectManager:setFillType(trigger.effects, trigger.selectedFillType)
 				trigger.autoStart = false
@@ -1479,7 +1479,7 @@ function courseplay:setFillOnTrigger(vehicle,workTool,fillOrder,trigger,triggerI
 		--stop filling
 		if trigger.onActivateObject then 
 			if trigger.isLoading then
-				trigger:onActivateObject(vehicle)
+				courseplay:activateTriggerForVehicle(trigger, vehicle);
 			end
 		elseif trigger.sourceObject then
 			workTool:setFillUnitIsFilling(false)							

--- a/triggers.lua
+++ b/triggers.lua
@@ -649,6 +649,32 @@ function courseplay:printTipTriggersFruits(trigger)
 	end
 end;
 
+-- Custom version of trigger:onActivateObject to allow activating for a non-controlled vehicle
+function courseplay:activateTriggerForVehicle(trigger, vehicle)
+	--Cache giant values to restore later
+	local defaultGetFarmIdFunction = g_currentMission.getFarmId;
+	local oldControlledVehicle = g_currentMission.controlledVehicle;
+
+	--Override farm id to match the calling vehicle (fixes issue when obtaining fill levels)
+	local overriddenFarmIdFunc = function()
+		local ownerFarmId = vehicle:getOwnerFarmId()
+		courseplay.debugVehicle(19, vehicle, 'Overriding farm id during trigger activation to %d', ownerFarmId);
+		return ownerFarmId;
+	end
+	g_currentMission.getFarmId = overriddenFarmIdFunc;
+
+	--Override controlled vehicle if I'm not in it
+	if g_currentMission.controlledVehicle ~= vehicle then
+		g_currentMission.controlledVehicle = vehicle;
+	end
+
+	--Call giant method with new params set
+	trigger:onActivateObject();
+
+	--Restore previous values
+	g_currentMission.getFarmId = defaultGetFarmIdFunction;
+	g_currentMission.controlledVehicle = oldControlledVehicle;
+end
 
 
 --------------------------------------------------


### PR DESCRIPTION
Fixes an issue where load triggers from silos were not working correctly in multiplayer with multiple farms. This fixes both refill courses, and mode 1 filling. I think this may fix https://github.com/Courseplay/courseplay/issues/4943.