### PR TITLE
Fixed file name on download instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Courseplay Six Beta for Farming Simulator 2019
 
- **[Download the latest developer version](https://github.com/Courseplay/courseplay/releases)** (the file Courseplay_[version].zip).
+ **[Download the latest developer version](https://github.com/Courseplay/courseplay/releases)** (the file FS19_Courseplay.zip).
 
 ## Note that the current version has limited multiplayer support!
 


### PR DESCRIPTION
As suggested in #5286, the mod file name is now consistently named `FS19_Courseplay.zip`.