### PR TITLE
Added shields

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,5 @@
 # Courseplay Six Beta for Farming Simulator 2019
+[![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/courseplay/Courseplay?include_prereleases&style=flat-square)](https://github.com/Courseplay/courseplay/releases/latest) [![GitHub Pre-Releases (by Asset)](https://img.shields.io/github/downloads-pre/Courseplay/courseplay/latest/FS19_Courseplay.zip?style=flat-square)](https://github.com/Courseplay/courseplay/releases/latest/download/FS19_Courseplay.zip) [![GitHub issues](https://img.shields.io/github/issues/Courseplay/courseplay?style=flat-square)](https://github.com/Courseplay/courseplay/issues)
 
  **[Download the latest developer version](https://github.com/Courseplay/courseplay/releases/latest)** (the file FS19_Courseplay.zip).
 


### PR DESCRIPTION
Added shields/badges from [Shields.io](https://shields.io) to the readme. They click!

- First one tells the latest version number, and links to it.
- Second one counts the downloads of the latest version, and is a link to download it directly.
- Third one counts open issues, and links to the issues page.

I think those ones fit nicely there, and are a nice touch to give some life to the readme.