### PR TITLE
Fixed errors raised when stopping courseplay workers in multiplayer.

### DIFF
--- a/FieldworkAIDriver.lua
+++ b/FieldworkAIDriver.lua
@@ -288,9 +288,13 @@ end
 
 function FieldworkAIDriver:stop(msgReference)
 	self:stopWork()
-	-- persist last fieldwork waypoint data (for 'start at current waypoint')
-	self.aiDriverData.lastFieldworkCourseHash = self.fieldworkCourse:getHash()
-	self.aiDriverData.lastFieldworkWaypointIx = self.fieldworkCourse:getCurrentWaypointIx()
+	-- Issue with persisting fieldwork data in multiplayer, as the client doesn't maintain the fieldworkcourse (client never calls start)
+	-- Persisted fieldwork data isn't needed by the client anyway, as its all handled by the server (also in start)
+	if g_server ~= nil then
+		-- persist last fieldwork waypoint data (for 'start at current waypoint')
+		self.aiDriverData.lastFieldworkCourseHash = self.fieldworkCourse:getHash()
+		self.aiDriverData.lastFieldworkWaypointIx = self.fieldworkCourse:getCurrentWaypointIx()
+	end
 	AIDriver.stop(self, msgReference)
 	-- Restore alignment settings. TODO: remove this setting from the HUD and always enable it
 	self.vehicle.cp.alignment.enabled = self.alignmentEnabled


### PR DESCRIPTION
Fixes a lua crash when a courseplay worker stops in multiplayer. I was hoping for a nicer fix than this, but this seems to resolve the issue without adding too much risk. Hopefully this can be tidied up in the future? (I'm not too sure why AIDriver.stop is called on the client, but start isn't for example). I think this fixes a host of issues:
https://github.com/Courseplay/courseplay/issues/5273
https://github.com/Courseplay/courseplay/issues/5240
https://github.com/Courseplay/courseplay/issues/5223
https://github.com/Courseplay/courseplay/issues/5150
https://github.com/Courseplay/courseplay/issues/5087
https://github.com/Courseplay/courseplay/issues/5061
https://github.com/Courseplay/courseplay/issues/5013