### PR TITLE
Fixed issue with toggling some settings when running multiplayer, when multiple players are active.

### DIFF
--- a/hud.lua
+++ b/hud.lua
@@ -2317,7 +2317,7 @@ function courseplay.hud:setAIDriverContent(vehicle)
 	self:addRowButton(vehicle,'startStop', 1, 1, 1 )
 	self:addRowButton(vehicle,'start_record', 1, 1, 2 )
 	self:addRowButton(vehicle,'cancelWait', 1, 2, 1 )
-	self:addRowButton(vehicle,'changeStartAtPoint', 1, 2, 2 )
+	self:addRowButton(vehicle,'changeStartAtPoint', 1, 2, 2 ):setOnlyCallLocal();
 	self:addRowButton(vehicle,'setStopAtEnd', 1, 3, 1 )
 	self:addSettingsRowWithArrows(vehicle,'switchDriverCopy', 1, 3, 2 )
 	self:setupCopyCourseButton(vehicle, 1, 3)
@@ -2389,7 +2389,7 @@ function courseplay.hud:setFieldWorkAIDriverContent(vehicle)
 	self:setupCustomFieldEdgeButtons(vehicle,1,5)
 	self:addRowButton(vehicle,'addCustomSingleFieldEdgeToList', 1, 6, 1 )
 	-- shown in place of the custom field row when a course is loaded
-	self:addRowButton(vehicle,'toggleReturnToFirstPoint', 1, 5, 1 )
+	self:addRowButton(vehicle,'toggleReturnToFirstPoint', 1, 5, 1 ):setOnlyCallLocal()
 
 	--page 3 settings
 	self:enablePageButton(vehicle, 3)
@@ -2398,7 +2398,7 @@ function courseplay.hud:setFieldWorkAIDriverContent(vehicle)
 	self:setupCalculateWorkWidthButton(vehicle,3, 2)
 	self:addRowButton(vehicle,'toggleConvoyActive', 3, 3, 1 )
 	self:addSettingsRow(vehicle,'setConvoyMinDistance', 3, 4, 1 )
-	self:addRowButton(vehicle,'toggleAutoDriveMode', 3, 8, 1 )
+	self:addRowButton(vehicle,'toggleAutoDriveMode', 3, 8, 1 ):setOnlyCallLocal();
 
 	
 	--page 7
@@ -2409,7 +2409,7 @@ function courseplay.hud:setFieldWorkAIDriverContent(vehicle)
 	self:enablePageButton(vehicle, 8)
 	self:addSettingsRowWithArrows(vehicle,'changeLaneNumber', 8, 1, 1 )
 	self:addSettingsRowWithArrows(vehicle,'changeLaneOffset', 8, 1, 2 )
-	self:addRowButton(vehicle,'toggleSymmetricLaneChange', 8, 2, 1 )
+	self:addRowButton(vehicle,'toggleSymmetricLaneChange', 8, 2, 1 ):setOnlyCallLocal();
 	self:addRowButton(vehicle,'toggleTurnOnField', 8, 3, 1 )
 	self:addRowButton(vehicle,'toggleRealisticDriving', 8, 4, 1 )
 	self:addSettingsRowWithArrows(vehicle,'changeToolOffsetX', 8, 5, 1 )
@@ -2442,7 +2442,7 @@ function courseplay.hud:setCombineAIDriverContent(vehicle)
 		self:addRowButton(vehicle,'toggleTurnStage', 0, 5, 1 )
 	else
 		self:addRowButton(vehicle,'toggleDriverPriority', 0, 4, 1 )
-		self:addRowButton(vehicle,'toggleStopWhenUnloading', 0, 5, 1 )
+		self:addRowButton(vehicle,'toggleStopWhenUnloading', 0, 5, 1 ):setOnlyCallLocal();
 		self:addRowButton(vehicle,'changeHeadlandReverseManeuverType', 0, 6, 1 )
 	end
 	self:setReloadPageOrder(vehicle, -1, true)


### PR DESCRIPTION
Fixes issue with some settings being toggled multiple times every time they are pressed, when multiple players are active. For example with 2 players, click a boolean value it toggles true/false/true so false can never be selected.

Should fix https://github.com/Courseplay/courseplay/issues/5118