### PR TITLE
Change distanceToObject calculation 

### DIFF
--- a/distance.lua
+++ b/distance.lua
@@ -25,15 +25,11 @@ function courseplay:distanceCheck(vehicle)
 	courseplay:setInfoText(vehicle, ('COURSEPLAY_DISTANCE;%d'):format(courseplay:distance(ctx, ctz, cx, cz)));
 end;
 
-
 function courseplay:distanceToObject(vehicle, object)
-	-- TODO: use localToLocal()
-	local x, y, z = getWorldTranslation(vehicle.cp.directionNode or vehicle.rootNode);
-	local ox, oy, oz = worldToLocal(object.rootNode, x, y, z);
-
-	return MathUtil.vector2Length(ox, oz);
-end;
-
+	local node1 = vehicle.cp.directionNode or vehicle.rootNode
+	local node2 = object.rootNode or object.nodeId
+	return calcDistanceFrom(node1, node2)
+end
 
 function courseplay:distanceToPoint(vehicle, x, y, z)
 	local ox, oy, oz = worldToLocal(vehicle.cp.directionNode, x, y, z);


### PR DESCRIPTION
Hereby I porpose a change for the `distanceToObject` function.

If the traffic collision is not meant for all objects (what looks like it (somehow) when I trace the places it gets called) it might be wise to confirm that the object you're dealing with is indeed a vehicle:

`object:isa(Vehicle)`