### PR TITLE
Mode 9 issue if the shovel is not fully empty when unloading

### DIFF
--- a/ShovelModeAIDriver.lua
+++ b/ShovelModeAIDriver.lua
@@ -161,14 +161,12 @@ function ShovelModeAIDriver:drive(dt)
 
 		if self:getIsShovelFull() or self:isAtEnd() then
 			if self:getTargetIsOnBunkerWallColumn() then
-				self:setShovelToPositionFinshed(3,dt)
 				self.tempTarget = self:getTargetToStraightOut()
 				self:setShovelState(self.states.STATE_REVERSE_STRAIGHT_OUT_OF_SILO)
 			else
 				local _,_,Zoffset = self.course:getWaypointLocalPosition(self.vehicle.cp.directionNode, self.shovelFillStartPoint)
 				local newPoint = self.course:getNextRevWaypointIxFromVehiclePosition(self.ppc:getCurrentWaypointIx(), self.vehicle.cp.directionNode,-Zoffset)
 				self.ppc:initialize(newPoint)
-				self:setShovelToPositionFinshed(3,dt)
 				self:setShovelState(self.states.STATE_REVERSE_OUT_OF_SILO)
 				self.bestTarget = nil
 			end

--- a/ShovelModeAIDriver.lua
+++ b/ShovelModeAIDriver.lua
@@ -161,14 +161,14 @@ function ShovelModeAIDriver:drive(dt)
 
 		if self:getIsShovelFull() or self:isAtEnd() then
 			if self:getTargetIsOnBunkerWallColumn() then
-				self:setShovelToPositionFinshed(3,dt) then
+				self:setShovelToPositionFinshed(3,dt)
 				self.tempTarget = self:getTargetToStraightOut()
 				self:setShovelState(self.states.STATE_REVERSE_STRAIGHT_OUT_OF_SILO)
 			else
 				local _,_,Zoffset = self.course:getWaypointLocalPosition(self.vehicle.cp.directionNode, self.shovelFillStartPoint)
 				local newPoint = self.course:getNextRevWaypointIxFromVehiclePosition(self.ppc:getCurrentWaypointIx(), self.vehicle.cp.directionNode,-Zoffset)
 				self.ppc:initialize(newPoint)
-				self:setShovelToPositionFinshed(3,dt) then
+				self:setShovelToPositionFinshed(3,dt)
 				self:setShovelState(self.states.STATE_REVERSE_OUT_OF_SILO)
 				self.bestTarget = nil
 			end

--- a/ShovelModeAIDriver.lua
+++ b/ShovelModeAIDriver.lua
@@ -161,12 +161,14 @@ function ShovelModeAIDriver:drive(dt)
 
 		if self:getIsShovelFull() or self:isAtEnd() then
 			if self:getTargetIsOnBunkerWallColumn() then
+				self:setShovelToPositionFinshed(3,dt) then
 				self.tempTarget = self:getTargetToStraightOut()
 				self:setShovelState(self.states.STATE_REVERSE_STRAIGHT_OUT_OF_SILO)
 			else
 				local _,_,Zoffset = self.course:getWaypointLocalPosition(self.vehicle.cp.directionNode, self.shovelFillStartPoint)
 				local newPoint = self.course:getNextRevWaypointIxFromVehiclePosition(self.ppc:getCurrentWaypointIx(), self.vehicle.cp.directionNode,-Zoffset)
 				self.ppc:initialize(newPoint)
+				self:setShovelToPositionFinshed(3,dt) then
 				self:setShovelState(self.states.STATE_REVERSE_OUT_OF_SILO)
 				self.bestTarget = nil
 			end

--- a/ShovelModeAIDriver.lua
+++ b/ShovelModeAIDriver.lua
@@ -312,7 +312,7 @@ function ShovelModeAIDriver:getIsShovelFull()
 end
 
 function ShovelModeAIDriver:getIsShovelEmpty()
-	return self.vehicle.cp.shovel:getFillUnitFillLevel(1) >= self.vehicle.cp.shovel:getFillUnitCapacity(1)*0.01
+	return self.vehicle.cp.shovel:getFillUnitFillLevel(1) <= self.vehicle.cp.shovel:getFillUnitCapacity(1)*0.01
 end
 
 function ShovelModeAIDriver:getFillLevelDoesChange()

--- a/ShovelModeAIDriver.lua
+++ b/ShovelModeAIDriver.lua
@@ -312,7 +312,7 @@ function ShovelModeAIDriver:getIsShovelFull()
 end
 
 function ShovelModeAIDriver:getIsShovelEmpty()
-	return self.vehicle.cp.shovel:getFillUnitFillLevel(1) == 0
+	return self.vehicle.cp.shovel:getFillUnitFillLevel(1) >= self.vehicle.cp.shovel:getFillUnitCapacity(1)*0.01
 end
 
 function ShovelModeAIDriver:getFillLevelDoesChange()


### PR DESCRIPTION
I am not a developer, so this is just a suggestion. If that's not appropriate, just remove it.
I am having issues with mode 9. The main one is the loader stays stuck on top of the trailer because the shovel isn't fully empty. I just added something to the empty value so it consider the shovel empty from 1 % of the filling capacity.
I am also trying to understand why my loader keeps the shovel to the filling position until it gets out of the bunker. I can't find how we could set the shovel to get to transport position as soon as it is full (or 99% full)
Please be gentle with me ;)