### PR TITLE
Setting Shovel Position in STATE_REVERSE_STRAIGHT_OUT_OF_SILO

### DIFF
--- a/ShovelModeAIDriver.lua
+++ b/ShovelModeAIDriver.lua
@@ -175,6 +175,9 @@ function ShovelModeAIDriver:drive(dt)
 		return
 	elseif self.shovelState == self.states.STATE_REVERSE_STRAIGHT_OUT_OF_SILO then
 		self.refSpeed = self.vehicle.cp.speeds.reverse
+		if not self:setShovelToPositionFinshed(3,dt) then
+			self:hold()
+		end
 		if self:getIsReversedOutOfSilo() then
 			local _,_,Zoffset = self.course:getWaypointLocalPosition(self.vehicle.cp.directionNode, self.shovelFillStartPoint)
 			local newPoint = self.course:getNextRevWaypointIxFromVehiclePosition(self.ppc:getCurrentWaypointIx(), self.vehicle.cp.directionNode,-Zoffset)


### PR DESCRIPTION
The code for seting the shovel positon was missing in STATE_REVERSE_STRAIGHT_OUT_OF_SILO state. 
Fixes #5402