### PR TITLE
Update Fr_translation / Shovel full at 98% / Empty course for mode 6

### DIFF
--- a/LevelCompactAIDriver.lua
+++ b/LevelCompactAIDriver.lua
@@ -791,7 +791,7 @@ function LevelCompactAIDriver:getColumnsTargetHeight(newColumn)
 		totalFillLevel = totalFillLevel + self.vehicle.cp.BunkerSiloMap[i][newColumn].fillLevel
 	end
 	local newHeight = math.max(0.6,(totalFillLevel/1000)/totalArea)
-	self:debug("getTargetHeigth: totalFillLevel:%s; totalArea:%s Height%s",tostring(totalFillLevel),tostring(totalArea),tostring(newHeight))
+	self:debug("getTargetHeight: totalFillLevel:%s; totalArea:%s Height%s",tostring(totalFillLevel),tostring(totalArea),tostring(newHeight))
 	return newHeight
 	
 end

--- a/LevelCompactAIDriver.lua
+++ b/LevelCompactAIDriver.lua
@@ -636,10 +636,8 @@ function LevelCompactAIDriver:getDiffHeightforHeight(targetHeight)
 	local bladeTerrain = getTerrainHeightAtWorldPos(g_currentMission.terrainRootNode, bladeX,bladeY,bladeZ);
 	local _,_,offSetZ = worldToLocal(self.vehicle.rootNode,bladeX,bladeY,bladeZ)
 	local _,projectedTractorY,_  = localToWorld(self.vehicle.rootNode,0,0,offSetZ)
-
-	return self.targetHeight
+		return targetHeight
 end
-
 
 function LevelCompactAIDriver:recordAlphaList()
 	local blade = self.vehicle.cp.workTools[1]

--- a/LevelCompactAIDriver.lua
+++ b/LevelCompactAIDriver.lua
@@ -636,9 +636,10 @@ function LevelCompactAIDriver:getDiffHeightforHeight(targetHeight)
 	local bladeTerrain = getTerrainHeightAtWorldPos(g_currentMission.terrainRootNode, bladeX,bladeY,bladeZ);
 	local _,_,offSetZ = worldToLocal(self.vehicle.rootNode,bladeX,bladeY,bladeZ)
 	local _,projectedTractorY,_  = localToWorld(self.vehicle.rootNode,0,0,offSetZ)
-		end
-	return targetHeight - (projectedTractorY-bladeTerrain)
+
+	return targetHeight- (projectedTractorY-bladeTerrain)
 end
+
 
 function LevelCompactAIDriver:recordAlphaList()
 	local blade = self.vehicle.cp.workTools[1]
@@ -790,7 +791,7 @@ function LevelCompactAIDriver:getColumnsTargetHeight(newColumn)
 		totalFillLevel = totalFillLevel + self.vehicle.cp.BunkerSiloMap[i][newColumn].fillLevel
 	end
 	local newHeight = math.max(0.6,(totalFillLevel/1000)/totalArea)
-	self:debug("getTargetHeight: totalFillLevel:%s; totalArea:%s Height%s",tostring(totalFillLevel),tostring(totalArea),tostring(newHeight))
+	self:debug("getTargetHeigth: totalFillLevel:%s; totalArea:%s Height%s",tostring(totalFillLevel),tostring(totalArea),tostring(newHeight))
 	return newHeight
 	
 end

--- a/LevelCompactAIDriver.lua
+++ b/LevelCompactAIDriver.lua
@@ -636,7 +636,8 @@ function LevelCompactAIDriver:getDiffHeightforHeight(targetHeight)
 	local bladeTerrain = getTerrainHeightAtWorldPos(g_currentMission.terrainRootNode, bladeX,bladeY,bladeZ);
 	local _,_,offSetZ = worldToLocal(self.vehicle.rootNode,bladeX,bladeY,bladeZ)
 	local _,projectedTractorY,_  = localToWorld(self.vehicle.rootNode,0,0,offSetZ)
-		return targetHeight
+		end
+	return targetHeight - (projectedTractorY-bladeTerrain)
 end
 
 function LevelCompactAIDriver:recordAlphaList()

--- a/LevelCompactAIDriver.lua
+++ b/LevelCompactAIDriver.lua
@@ -637,7 +637,7 @@ function LevelCompactAIDriver:getDiffHeightforHeight(targetHeight)
 	local _,_,offSetZ = worldToLocal(self.vehicle.rootNode,bladeX,bladeY,bladeZ)
 	local _,projectedTractorY,_  = localToWorld(self.vehicle.rootNode,0,0,offSetZ)
 
-	return targetHeight- (projectedTractorY-bladeTerrain)
+	return self.targetHeight
 end
 
 

--- a/ShovelModeAIDriver.lua
+++ b/ShovelModeAIDriver.lua
@@ -182,7 +182,6 @@ function ShovelModeAIDriver:drive(dt)
 			self.ppc:initialize(newPoint)
 			self:setShovelState(self.states.STATE_TRANSPORT)
 			self.bestTarget = nil
-		end
 			if self:setShovelToPositionFinshed(3,dt) then
 			self:hold()
 		end

--- a/ShovelModeAIDriver.lua
+++ b/ShovelModeAIDriver.lua
@@ -26,13 +26,16 @@ handles "mode9": Fill and empty shovel
 	d) drive reverse (back through silo) and turn at end
 	e) drive forwards to bunker, set waiting point #3 and unload
 	f) drive backwards, turn, drive forwards until before start
+
 1)  drive course until waiting point #1 - set shovel to "filling" rotation
 2)  [repeat] if lastFillLevel == currentFillLevel: drive ahead until is filling
 2b) if waiting point #2 is reached, area is empty -> stop work
 3)  if currentFillLevel == 100: set shovel to "transport" rotation, find closest point that's behind tractor, drive course from there
 4)  drive course forwards until waiting point #3 - set shovel to "empty" rotation
 5)  drive course with recorded direction (most likely in reverse) until end - continue and repeat to 1)
+
 NOTE: rotation: movingTool.curRot[1] (only x-axis) / translation: movingTool.curTrans[3] (only z-axis)
+
 NOTE: although lx and lz are passed in as parameters, they are never used.
 ]]
 

--- a/ShovelModeAIDriver.lua
+++ b/ShovelModeAIDriver.lua
@@ -163,7 +163,6 @@ function ShovelModeAIDriver:drive(dt)
 			if self:getTargetIsOnBunkerWallColumn() then
 				self.tempTarget = self:getTargetToStraightOut()
 				self:setShovelState(self.states.STATE_REVERSE_STRAIGHT_OUT_OF_SILO)
-				self:setShovelToPositionFinshed(3,dt)
 			else
 				local _,_,Zoffset = self.course:getWaypointLocalPosition(self.vehicle.cp.directionNode, self.shovelFillStartPoint)
 				local newPoint = self.course:getNextRevWaypointIxFromVehiclePosition(self.ppc:getCurrentWaypointIx(), self.vehicle.cp.directionNode,-Zoffset)

--- a/ShovelModeAIDriver.lua
+++ b/ShovelModeAIDriver.lua
@@ -161,6 +161,7 @@ function ShovelModeAIDriver:drive(dt)
 
 		if self:getIsShovelFull() or self:isAtEnd() then
 			if self:getTargetIsOnBunkerWallColumn() then
+				if self:setShovelToPositionFinshed(2,dt) then
 				self.tempTarget = self:getTargetToStraightOut()
 				self:setShovelState(self.states.STATE_REVERSE_STRAIGHT_OUT_OF_SILO)
 			else

--- a/ShovelModeAIDriver.lua
+++ b/ShovelModeAIDriver.lua
@@ -161,14 +161,12 @@ function ShovelModeAIDriver:drive(dt)
 
 		if self:getIsShovelFull() or self:isAtEnd() then
 			if self:getTargetIsOnBunkerWallColumn() then
-				self:setShovelToPositionFinshed(3,dt)
 				self.tempTarget = self:getTargetToStraightOut()
 				self:setShovelState(self.states.STATE_REVERSE_STRAIGHT_OUT_OF_SILO)
 			else
 				local _,_,Zoffset = self.course:getWaypointLocalPosition(self.vehicle.cp.directionNode, self.shovelFillStartPoint)
 				local newPoint = self.course:getNextRevWaypointIxFromVehiclePosition(self.ppc:getCurrentWaypointIx(), self.vehicle.cp.directionNode,-Zoffset)
 				self.ppc:initialize(newPoint)
-				self:setShovelToPositionFinshed(3,dt)
 				self:setShovelState(self.states.STATE_REVERSE_OUT_OF_SILO)
 				self.bestTarget = nil
 			end

--- a/ShovelModeAIDriver.lua
+++ b/ShovelModeAIDriver.lua
@@ -169,6 +169,8 @@ function ShovelModeAIDriver:drive(dt)
 				self.ppc:initialize(newPoint)
 				self:setShovelState(self.states.STATE_REVERSE_OUT_OF_SILO)
 				self.bestTarget = nil
+			if not self:setShovelToPositionFinshed(3,dt) then
+			self:hold()
 			end
 		end
 
@@ -195,7 +197,7 @@ function ShovelModeAIDriver:drive(dt)
 	elseif self.shovelState == self.states.STATE_REVERSE_OUT_OF_SILO then
 		self.refSpeed = self.vehicle.cp.speeds.reverse
 		if not self:setShovelToPositionFinshed(3,dt) then
-			self:hold()
+			setShovelToPositionFinshed(3,dt)
 		end
 		if not self.course:isReverseAt(self.ppc:getCurrentWaypointIx()) then
 			self:setShovelState(self.states.STATE_TRANSPORT);

--- a/ShovelModeAIDriver.lua
+++ b/ShovelModeAIDriver.lua
@@ -161,7 +161,7 @@ function ShovelModeAIDriver:drive(dt)
 
 		if self:getIsShovelFull() or self:isAtEnd() then
 			if self:getTargetIsOnBunkerWallColumn() then
-				if self:setShovelToPositionFinshed(2,dt) then
+				if self:setShovelToPositionFinshed(3,dt) then
 				self.tempTarget = self:getTargetToStraightOut()
 				self:setShovelState(self.states.STATE_REVERSE_STRAIGHT_OUT_OF_SILO)
 			else

--- a/ShovelModeAIDriver.lua
+++ b/ShovelModeAIDriver.lua
@@ -170,12 +170,13 @@ function ShovelModeAIDriver:drive(dt)
 				self:setShovelState(self.states.STATE_REVERSE_OUT_OF_SILO)
 				self.bestTarget = nil
 			end
+			if self:setShovelToPositionFinshed(3,dt) then
+				self:hold()
 		end
 
 		return
 	elseif self.shovelState == self.states.STATE_REVERSE_STRAIGHT_OUT_OF_SILO then
 		self.refSpeed = self.vehicle.cp.speeds.reverse
-		if self:setShovelToPositionFinshed(3,dt) then
 		if self:getIsReversedOutOfSilo() then
 			local _,_,Zoffset = self.course:getWaypointLocalPosition(self.vehicle.cp.directionNode, self.shovelFillStartPoint)
 			local newPoint = self.course:getNextRevWaypointIxFromVehiclePosition(self.ppc:getCurrentWaypointIx(), self.vehicle.cp.directionNode,-Zoffset)

--- a/ShovelModeAIDriver.lua
+++ b/ShovelModeAIDriver.lua
@@ -305,7 +305,7 @@ function ShovelModeAIDriver:setShovelToPositionFinshed(stage,dt)
 end
 
 function ShovelModeAIDriver:getIsShovelFull()
-	return self.vehicle.cp.shovel:getFillUnitFillLevel(1) >= self.vehicle.cp.shovel:getFillUnitCapacity(1)*0.99
+	return self.vehicle.cp.shovel:getFillUnitFillLevel(1) >= self.vehicle.cp.shovel:getFillUnitCapacity(1)*0.98
 end
 
 function ShovelModeAIDriver:getIsShovelEmpty()

--- a/ShovelModeAIDriver.lua
+++ b/ShovelModeAIDriver.lua
@@ -170,8 +170,7 @@ function ShovelModeAIDriver:drive(dt)
 				self:setShovelState(self.states.STATE_REVERSE_OUT_OF_SILO)
 				self.bestTarget = nil
 			end
-			if self:setShovelToPositionFinshed(3,dt) then
-				self:hold()
+			
 		end
 
 		return
@@ -183,6 +182,9 @@ function ShovelModeAIDriver:drive(dt)
 			self.ppc:initialize(newPoint)
 			self:setShovelState(self.states.STATE_TRANSPORT)
 			self.bestTarget = nil
+		end
+			if self:setShovelToPositionFinshed(3,dt) then
+			self:hold()
 		end
 		--drive to temp target
 		if self.tempTarget then

--- a/ShovelModeAIDriver.lua
+++ b/ShovelModeAIDriver.lua
@@ -161,14 +161,14 @@ function ShovelModeAIDriver:drive(dt)
 
 		if self:getIsShovelFull() or self:isAtEnd() then
 			if self:getTargetIsOnBunkerWallColumn() then
-				self:setShovelToPositionFinshed(3,dt) then
+				self:setShovelToPositionFinshed(3,dt)
 				self.tempTarget = self:getTargetToStraightOut()
 				self:setShovelState(self.states.STATE_REVERSE_STRAIGHT_OUT_OF_SILO)
 			else
 				local _,_,Zoffset = self.course:getWaypointLocalPosition(self.vehicle.cp.directionNode, self.shovelFillStartPoint)
 				local newPoint = self.course:getNextRevWaypointIxFromVehiclePosition(self.ppc:getCurrentWaypointIx(), self.vehicle.cp.directionNode,-Zoffset)
 				self.ppc:initialize(newPoint)
-				self:setShovelToPositionFinshed(3,dt) then
+				self:setShovelToPositionFinshed(3,dt)
 				self:setShovelState(self.states.STATE_REVERSE_OUT_OF_SILO)
 				self.bestTarget = nil
 			end

--- a/ShovelModeAIDriver.lua
+++ b/ShovelModeAIDriver.lua
@@ -163,14 +163,13 @@ function ShovelModeAIDriver:drive(dt)
 			if self:getTargetIsOnBunkerWallColumn() then
 				self.tempTarget = self:getTargetToStraightOut()
 				self:setShovelState(self.states.STATE_REVERSE_STRAIGHT_OUT_OF_SILO)
+				self:setShovelToPositionFinshed(3,dt)
 			else
 				local _,_,Zoffset = self.course:getWaypointLocalPosition(self.vehicle.cp.directionNode, self.shovelFillStartPoint)
 				local newPoint = self.course:getNextRevWaypointIxFromVehiclePosition(self.ppc:getCurrentWaypointIx(), self.vehicle.cp.directionNode,-Zoffset)
 				self.ppc:initialize(newPoint)
 				self:setShovelState(self.states.STATE_REVERSE_OUT_OF_SILO)
 				self.bestTarget = nil
-			if not self:setShovelToPositionFinshed(3,dt) then
-			self:hold()
 			end
 		end
 
@@ -196,8 +195,6 @@ function ShovelModeAIDriver:drive(dt)
 		end
 	elseif self.shovelState == self.states.STATE_REVERSE_OUT_OF_SILO then
 		self.refSpeed = self.vehicle.cp.speeds.reverse
-		if not self:setShovelToPositionFinshed(3,dt) then
-			setShovelToPositionFinshed(3,dt)
 		end
 		if not self.course:isReverseAt(self.ppc:getCurrentWaypointIx()) then
 			self:setShovelState(self.states.STATE_TRANSPORT);

--- a/ShovelModeAIDriver.lua
+++ b/ShovelModeAIDriver.lua
@@ -1,17 +1,14 @@
 --[[
 This file is part of Courseplay (https://github.com/Courseplay/courseplay)
 Copyright (C) 2018 Thomas Gaertner
-
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
-
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ]]
@@ -26,16 +23,13 @@ handles "mode9": Fill and empty shovel
 	d) drive reverse (back through silo) and turn at end
 	e) drive forwards to bunker, set waiting point #3 and unload
 	f) drive backwards, turn, drive forwards until before start
-
 1)  drive course until waiting point #1 - set shovel to "filling" rotation
 2)  [repeat] if lastFillLevel == currentFillLevel: drive ahead until is filling
 2b) if waiting point #2 is reached, area is empty -> stop work
 3)  if currentFillLevel == 100: set shovel to "transport" rotation, find closest point that's behind tractor, drive course from there
 4)  drive course forwards until waiting point #3 - set shovel to "empty" rotation
 5)  drive course with recorded direction (most likely in reverse) until end - continue and repeat to 1)
-
 NOTE: rotation: movingTool.curRot[1] (only x-axis) / translation: movingTool.curTrans[3] (only z-axis)
-
 NOTE: although lx and lz are passed in as parameters, they are never used.
 ]]
 
@@ -170,14 +164,13 @@ function ShovelModeAIDriver:drive(dt)
 				self:setShovelState(self.states.STATE_REVERSE_OUT_OF_SILO)
 				self.bestTarget = nil
 			end
-			
 		end
 
 		return
 	elseif self.shovelState == self.states.STATE_REVERSE_STRAIGHT_OUT_OF_SILO then
 		self.refSpeed = self.vehicle.cp.speeds.reverse
 		if not self:setShovelToPositionFinshed(3,dt) then
-		self:hold()
+			self:hold()
 		end
 		if self:getIsReversedOutOfSilo() then
 			local _,_,Zoffset = self.course:getWaypointLocalPosition(self.vehicle.cp.directionNode, self.shovelFillStartPoint)
@@ -198,6 +191,8 @@ function ShovelModeAIDriver:drive(dt)
 		end
 	elseif self.shovelState == self.states.STATE_REVERSE_OUT_OF_SILO then
 		self.refSpeed = self.vehicle.cp.speeds.reverse
+		if not self:setShovelToPositionFinshed(3,dt) then
+			self:hold()
 		end
 		if not self.course:isReverseAt(self.ppc:getCurrentWaypointIx()) then
 			self:setShovelState(self.states.STATE_TRANSPORT);
@@ -453,4 +448,8 @@ function ShovelModeAIDriver:getIsReversedOutOfSilo()
 	local x,z = self.vehicle.cp.BunkerSiloMap[1][self.bestTarget.column].cx,self.vehicle.cp.BunkerSiloMap[1][self.bestTarget.column].cz
 	local px,py,pz = worldToLocal(self.vehicle.cp.directionNode,x,0,z)
 	return pz > 4
+end
+
+function ShovelModeAIDriver:setLightsMask(vehicle)
+	vehicle:setLightsTypesMask(courseplay.lights.HEADLIGHT_FULL)
 end

--- a/ShovelModeAIDriver.lua
+++ b/ShovelModeAIDriver.lua
@@ -182,8 +182,6 @@ function ShovelModeAIDriver:drive(dt)
 			self.ppc:initialize(newPoint)
 			self:setShovelState(self.states.STATE_TRANSPORT)
 			self.bestTarget = nil
-			if self:setShovelToPositionFinshed(3,dt) then
-			self:hold()
 		end
 		--drive to temp target
 		if self.tempTarget then

--- a/ShovelModeAIDriver.lua
+++ b/ShovelModeAIDriver.lua
@@ -1,14 +1,17 @@
 --[[
 This file is part of Courseplay (https://github.com/Courseplay/courseplay)
 Copyright (C) 2018 Thomas Gaertner
+
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ]]

--- a/ShovelModeAIDriver.lua
+++ b/ShovelModeAIDriver.lua
@@ -161,12 +161,14 @@ function ShovelModeAIDriver:drive(dt)
 
 		if self:getIsShovelFull() or self:isAtEnd() then
 			if self:getTargetIsOnBunkerWallColumn() then
+				self:setShovelToPositionFinshed(3,dt) then
 				self.tempTarget = self:getTargetToStraightOut()
 				self:setShovelState(self.states.STATE_REVERSE_STRAIGHT_OUT_OF_SILO)
 			else
 				local _,_,Zoffset = self.course:getWaypointLocalPosition(self.vehicle.cp.directionNode, self.shovelFillStartPoint)
 				local newPoint = self.course:getNextRevWaypointIxFromVehiclePosition(self.ppc:getCurrentWaypointIx(), self.vehicle.cp.directionNode,-Zoffset)
 				self.ppc:initialize(newPoint)
+				self:setShovelToPositionFinshed(3,dt) then
 				self:setShovelState(self.states.STATE_REVERSE_OUT_OF_SILO)
 				self.bestTarget = nil
 			end

--- a/ShovelModeAIDriver.lua
+++ b/ShovelModeAIDriver.lua
@@ -161,7 +161,6 @@ function ShovelModeAIDriver:drive(dt)
 
 		if self:getIsShovelFull() or self:isAtEnd() then
 			if self:getTargetIsOnBunkerWallColumn() then
-				if self:setShovelToPositionFinshed(3,dt) then
 				self.tempTarget = self:getTargetToStraightOut()
 				self:setShovelState(self.states.STATE_REVERSE_STRAIGHT_OUT_OF_SILO)
 			else
@@ -176,6 +175,7 @@ function ShovelModeAIDriver:drive(dt)
 		return
 	elseif self.shovelState == self.states.STATE_REVERSE_STRAIGHT_OUT_OF_SILO then
 		self.refSpeed = self.vehicle.cp.speeds.reverse
+		if self:setShovelToPositionFinshed(3,dt) then
 		if self:getIsReversedOutOfSilo() then
 			local _,_,Zoffset = self.course:getWaypointLocalPosition(self.vehicle.cp.directionNode, self.shovelFillStartPoint)
 			local newPoint = self.course:getNextRevWaypointIxFromVehiclePosition(self.ppc:getCurrentWaypointIx(), self.vehicle.cp.directionNode,-Zoffset)

--- a/ShovelModeAIDriver.lua
+++ b/ShovelModeAIDriver.lua
@@ -176,6 +176,9 @@ function ShovelModeAIDriver:drive(dt)
 		return
 	elseif self.shovelState == self.states.STATE_REVERSE_STRAIGHT_OUT_OF_SILO then
 		self.refSpeed = self.vehicle.cp.speeds.reverse
+		if not self:setShovelToPositionFinshed(3,dt) then
+		self:hold()
+		end
 		if self:getIsReversedOutOfSilo() then
 			local _,_,Zoffset = self.course:getWaypointLocalPosition(self.vehicle.cp.directionNode, self.shovelFillStartPoint)
 			local newPoint = self.course:getNextRevWaypointIxFromVehiclePosition(self.ppc:getCurrentWaypointIx(), self.vehicle.cp.directionNode,-Zoffset)

--- a/ShovelModeAIDriver.lua
+++ b/ShovelModeAIDriver.lua
@@ -312,7 +312,7 @@ function ShovelModeAIDriver:getIsShovelFull()
 end
 
 function ShovelModeAIDriver:getIsShovelEmpty()
-	return self.vehicle.cp.shovel:getFillUnitFillLevel(1) >= self.vehicle.cp.shovel:getFillUnitCapacity(1)*0.01
+	return self.vehicle.cp.shovel:getFillUnitFillLevel(1) <= self.vehicle.cp.shovel:getFillUnitCapacity(1)*0.01
 end
 
 function ShovelModeAIDriver:getFillLevelDoesChange()

--- a/ShovelModeAIDriver.lua
+++ b/ShovelModeAIDriver.lua
@@ -312,7 +312,7 @@ function ShovelModeAIDriver:getIsShovelFull()
 end
 
 function ShovelModeAIDriver:getIsShovelEmpty()
-	return self.vehicle.cp.shovel:getFillUnitFillLevel(1) == 0
+	return self.vehicle.cp.shovel:getFillUnitFillLevel(1) >= self.vehicle.cp.shovel:getFillUnitCapacity(1)*0.01
 end
 
 function ShovelModeAIDriver:getFillLevelDoesChange()

--- a/UnloadableFieldworkAIDriver.lua
+++ b/UnloadableFieldworkAIDriver.lua
@@ -127,7 +127,7 @@ function UnloadableFieldworkAIDriver:driveUnloadOrRefill(dt)
 	end
 		
 	-- done tipping?
-	if self:hasTipTrigger() and self.vehicle.cp.totalFillLevel <= 1 then
+	if self:hasTipTrigger() and self.vehicle.cp.totalFillLevel <= 10 then
 		courseplay:resetTipTrigger(self.vehicle, true);
 	end
 		

--- a/UnloadableFieldworkAIDriver.lua
+++ b/UnloadableFieldworkAIDriver.lua
@@ -127,7 +127,7 @@ function UnloadableFieldworkAIDriver:driveUnloadOrRefill(dt)
 	end
 		
 	-- done tipping?
-	if self:hasTipTrigger() and self.vehicle.cp.totalFillLevel == 0 then
+	if self:hasTipTrigger() and self.vehicle.cp.totalFillLevel <= 1 then
 		courseplay:resetTipTrigger(self.vehicle, true);
 	end
 		

--- a/UnloadableFieldworkAIDriver.lua
+++ b/UnloadableFieldworkAIDriver.lua
@@ -127,7 +127,7 @@ function UnloadableFieldworkAIDriver:driveUnloadOrRefill(dt)
 	end
 		
 	-- done tipping?
-	if self:hasTipTrigger() and self.vehicle.cp.totalFillLevel <= 40 then
+	if self:hasTipTrigger() and self.vehicle.cp.totalFillLevel == 0 then
 		courseplay:resetTipTrigger(self.vehicle, true);
 	end
 		

--- a/UnloadableFieldworkAIDriver.lua
+++ b/UnloadableFieldworkAIDriver.lua
@@ -127,7 +127,7 @@ function UnloadableFieldworkAIDriver:driveUnloadOrRefill(dt)
 	end
 		
 	-- done tipping?
-	if self:hasTipTrigger() and self.vehicle.cp.totalFillLevel == 0 then
+	if self:hasTipTrigger() and self.vehicle.cp.totalFillLevel <= 10 then
 		courseplay:resetTipTrigger(self.vehicle, true);
 	end
 		

--- a/UnloadableFieldworkAIDriver.lua
+++ b/UnloadableFieldworkAIDriver.lua
@@ -127,7 +127,7 @@ function UnloadableFieldworkAIDriver:driveUnloadOrRefill(dt)
 	end
 		
 	-- done tipping?
-	if self:hasTipTrigger() and self.vehicle.cp.totalFillLevel <= 10 then
+	if self:hasTipTrigger() and self.vehicle.cp.totalFillLevel <= 40 then
 		courseplay:resetTipTrigger(self.vehicle, true);
 	end
 		

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -231,12 +231,13 @@
     <text name="COURSEPLAY_CENTER_MODE_UP_DOWN"							text="Allers Retours" />
     <text name="COURSEPLAY_CENTER_MODE_CIRCULAR"						text="Circulaire (par bloc)" />
     <text name="COURSEPLAY_CENTER_MODE_SPIRAL"						    text="Spirale (tourne autour)" />
-    <text name="COURSEPLAY_ACTIVATED" 						 			text="Activé" />
+	<text name="COURSEPLAY_CENTER_MODE_LANDS"						    text="Enrayure à travers (centre)" />
+	<text name="COURSEPLAY_ACTIVATED" 						 			text="Activé" />
     <text name="COURSEPLAY_NAME_ONLY" 									text="Nom seul" />
     <text name="COURSEPLAY_NAME_AND_COURSE" 							text="Nom et Course" />
     <text name="COURSEPLAY_DEACTIVATED" 						 		text="Désactivé" />
     <text name="COURSEPLAY_RIDGEMARKERS" 						 		text="Traceurs:" />
-	  <text name="COURSEPLAY_YES_NO_RIDGEMARKERS"							text="Gestion automatique des traceurs sur les semoirs" />
+	<text name="COURSEPLAY_YES_NO_RIDGEMARKERS"							text="Gestion automatique des traceurs sur les semoirs" />
     <text name="COURSEPLAY_UNLOADING_ON_FIELD" 					 		text="Déchargement à la parcelle" />
     <text name="COURSEPLAY_AUTOMATIC" 						 			text="Automatique" />
     <text name="COURSEPLAY_MANUAL" 							 			text="Manuellement" />
@@ -274,7 +275,7 @@
     <text name="COURSEPLAY_FIRST_POINT" 						 		text="Premier point" />
     <text name="COURSEPLAY_CURRENT_POINT" 						 		text="Point actuel" />
     <text name="COURSEPLAY_NEXT_POINT" 									text="Prochain point" />
-    <text name="COURSEPLAY_FIELD_EDGE_PATH" 					 		text="Tour de la parcelle" />
+    <text name="COURSEPLAY_FIELD_EDGE_PATH" 					 		text="Contour de la parcelle" />
     <text name="COURSEPLAY_FIELD" 							 			text="Parcelle" />
     <text name="COURSEPLAY_CURRENTLY_LOADED_COURSE" 					text="Course actuelle" />
     <text name="COURSEPLAY_FIELD_SCAN_IN_PROGRESS" 						text="Analyse des parcelles en cours" />
@@ -285,10 +286,10 @@
     <text name="COURSEPLAY_FILLEVEL" 						 			text="Niveau de remplissage" />
     <text name="COURSEPLAY_PICKUP_JAMMED" 						 		text=": le pickup est coincé" />
     <text name="COURSEPLAY_BALER_NEEDS_NETS" 					 		text=": la presse a besoin de filets" />
-    <text name="COURSEPLAY_SCAN_CURRENT_FIELD_EDGES" 					text="Calculer le tour de la parcelle actuelle" />
-    <text name="COURSEPLAY_CURRENT_FIELD_EDGE_PATH_NUMBER" 				text="Tour de la parcelle numéro" />
-    <text name="COURSEPLAY_ADD_CUSTOM_FIELD_EDGE_PATH_TO_LIST" 			text="Ajoute le tour de la parcelle %d à la liste" />
-    <text name="COURSEPLAY_OVERWRITE_CUSTOM_FIELD_EDGE_PATH_IN_LIST"	text="Écraser le tour de la parcelle %d dans la liste" />
+    <text name="COURSEPLAY_SCAN_CURRENT_FIELD_EDGES" 					text="Calculer le contour de la parcelle actuelle" />
+    <text name="COURSEPLAY_CURRENT_FIELD_EDGE_PATH_NUMBER" 				text="Contour de la parcelle numéro" />
+    <text name="COURSEPLAY_ADD_CUSTOM_FIELD_EDGE_PATH_TO_LIST" 			text="Ajoute le contour de la parcelle %d à la liste" />
+    <text name="COURSEPLAY_OVERWRITE_CUSTOM_FIELD_EDGE_PATH_IN_LIST"	text="Écraser le contour de la parcelle %d dans la liste" />
     <text name="COURSEPLAY_USER" 							 			text="Utilisateur" />
     <text name="COURSEPLAY_DAMAGE_SHOULD_BE_REPAIRED" 					text="devra bientôt être réparé" />
     <text name="COURSEPLAY_DAMAGE_MUST_BE_REPAIRED" 					text="doit être réparé" />


### PR DESCRIPTION
I set the full value of the shovel starting at 98 % to solve #5438, it might require more investigation on why the shovel isn't getting to 99 or 100 %

About the unload course for mode 6 : I ran into a problem quite often with forage wagons collecting grass and unloading it in a bunker silo. 1/4 or 1/5 of the time, the forage wagon is stuck on the silo because it has 2 or 3 liters of grass which can't be unload (even manually if I stop the course). With that "hack", the tractor moves forward anyway and dump the 2/3 liters in front of the bunker silo on its way back to the field. I tested it with grass and it works pretty well now. I also tested it with a bale collector without any issue. Not sure if there is any other equipment using that type of course I should have tried.