### PR TITLE
mode10: ensure proper state setup on new approach

### DIFF
--- a/LevelCompactAIDriver.lua
+++ b/LevelCompactAIDriver.lua
@@ -762,7 +762,8 @@ function LevelCompactAIDriver:getBestTargetFillUnitLeveling(Silo,lastDrivenColum
 								column = newColumn;
 								empty = false;
 								}]]
-			return self:getBestTargetFillUnitFillUp(Silo,{})
+			newBestTarget, firstLine = self:getBestTargetFillUnitFillUp(Silo,{})
+			return newBestTarget, firstLine, targetHeight
 		else
 			newColumn = lastDrivenColumn +1;
 			if newColumn > #vehicle.cp.BunkerSiloMap[1] then


### PR DESCRIPTION
I had some issues with a LUA-error when the tractor enters the bunker in leveling/compaction-mode in mode10 (also reported by someone else in #5302). From what I can gather, it's rooted in the fact that during the first approach after generating the bunker silo map the `LevelCompactAIDriver:getBestTargetFillUnitLeveling` function just dispatches to `LevelCompactAIDriver:getBestTargetFillUnitFillUp` which returns only two arguments instead of three expected from the `getBestTargetFillUnitLeveling` function.

This was introduced in 1e4c3d550da98f709e135d10143060069eeea9d0 and causes the `LevelCompactAIDriver:targetHeight` property to be undefined/nil. I'm not very familiar with the code base here, but from what I gather the best fix would just be to return the default `targetHeight` in combination with the returned values of the `getBestTargetFillUnitFillUp` function.

If this should be fixed in other ways I'm all ears and happy to see if I can produce a different fix for it.