### PR TITLE
Pathfinder tweaks to improve large field behaviour

### DIFF
--- a/course-generator/HybridAStar.lua
+++ b/course-generator/HybridAStar.lua
@@ -508,8 +508,10 @@ function HybridAStar:findPath(start, goal, turnRadius, userData, allowReverse, g
 						if self.analyticSolverEnabled then
 							local analyticSolution = self.analyticSolver:solve(succ, goal, turnRadius, allowReverse)
 							analyticSolutionCost = analyticSolution:getLength(turnRadius)
+							succ:updateH(goal, analyticSolutionCost)
+						else
+							succ:updateH(goal, 0, succ:distance(goal) * 1.5)
 						end
-						succ:updateH(goal, analyticSolutionCost)
 
 						--self:debug('     %s', tostring(succ))
 						if existingSuccNode then

--- a/course-generator/PathfinderUtil.lua
+++ b/course-generator/PathfinderUtil.lua
@@ -591,19 +591,19 @@ end
 ---@param maxFruitPercent number maximum percentage of fruit present before a node is marked as invalid (optional)
 function PathfinderUtil.startPathfindingFromVehicleToNode(vehicle, goalNode,
                                                           xOffset, zOffset, allowReverse,
-                                                          fieldNum, vehiclesToIgnore, maxFruitPercent)
+                                                          fieldNum, vehiclesToIgnore, maxFruitPercent, offFieldPenalty)
     local x, z, yRot = PathfinderUtil.getNodePositionAndDirection(AIDriverUtil.getDirectionNode(vehicle))
     local start = State3D(x, -z, courseGenerator.fromCpAngle(yRot))
     x, z, yRot = PathfinderUtil.getNodePositionAndDirection(goalNode, xOffset, zOffset)
     local goal = State3D(x, -z, courseGenerator.fromCpAngle(yRot))
-    return PathfinderUtil.startPathfindingFromVehicleToGoal(vehicle, start, goal, allowReverse, fieldNum, vehiclesToIgnore, maxFruitPercent)
+    return PathfinderUtil.startPathfindingFromVehicleToGoal(vehicle, start, goal, allowReverse, fieldNum, vehiclesToIgnore, maxFruitPercent, offFieldPenalty)
 end
 
 function PathfinderUtil.startPathfindingFromVehicleToGoal(vehicle, start, goal,
                                                           allowReverse, fieldNum,
-                                                          vehiclesToIgnore, maxFruitPercent)
+                                                          vehiclesToIgnore, maxFruitPercent, offFieldPenalty)
     PathfinderUtil.setUpVehicleCollisionData(vehicle, vehiclesToIgnore)
-    local parameters = PathfinderUtil.Parameters(maxFruitPercent or (vehicle.cp.realisticDriving and 50 or math.huge))
+    local parameters = PathfinderUtil.Parameters(maxFruitPercent or (vehicle.cp.realisticDriving and 50 or math.huge), offFieldPenalty or 1)
     local context = PathfinderUtil.Context(PathfinderUtil.VehicleData(vehicle, true, 0.2), PathfinderUtil.FieldData(fieldNum), parameters, vehiclesToIgnore)
     return PathfinderUtil.startPathfinding(start, goal, context, allowReverse)
 end

--- a/courseplay.lua
+++ b/courseplay.lua
@@ -43,6 +43,7 @@ courseplay.clock = 0;
 	['3e701b6620453edcd4c170543e72788b'] = true; -- Peter
 	['0d8e45a8ed916c1cd40820165b81e12d'] = true; -- Tensuko
 	['97c8e6d0d14f4e242c3c37af68cc376c'] = true; -- Dan
+	['8f5e9e8fb5a23375afbb3b7abbc6335c'] = true; -- Goof
 };
 
 local function initialize()


### PR DESCRIPTION
The h term in the A* algorithm is scaled too low to really do enough
when working on a path across a large distance. Quick and dirty scale by
50% pushes it more towards the "greedy" end and away from the "dijkstra"
end, though this does mean it likes to stick close to obstacles until it
gets a straighter shot to its goal. Need a better way to estimate that h
term.

Tried to hack together a way to have the pathfinder try something
different if it fails. For mode 2 it initially paths on the field, off
the fruit. If that fails, it tries looking further off the field. If
THAT fails it then tries a straight shot through the fruit as well.