### PR TITLE
fixes #5685 - Quick fix for ViconFastBale stopping

### DIFF
--- a/BalerAIDriver.lua
+++ b/BalerAIDriver.lua
@@ -71,8 +71,11 @@ function BalerAIDriver:handleBaler()
 					self.baler:setIsUnloadingBale(true, false)
 				end
 			elseif self.baler.spec_baler.unloadingState ~= Baler.UNLOADING_CLOSED then
-				allowedToDrive = false
-				if self.baler.spec_baler.unloadingState == Baler.UNLOADING_OPEN then
+				if fillLevel >= capacity then -- Only stop if capacity is full. Allowing for continuous balers such as the ViconFastBale
+					allowedToDrive = false
+				elseif fillLevel == 0 and self.baler.spec_baler.unloadingState == Baler.UNLOADING_CLOSING then
+					allowedToDrive = false
+				elseif self.baler.spec_baler.unloadingState == Baler.UNLOADING_OPEN then
 					self.baler:setIsUnloadingBale(false)
 				end
 			elseif fillLevel >= 0 and not self.baler:getIsTurnedOn() and self.baler.spec_baler.unloadingState == Baler.UNLOADING_CLOSED then


### PR DESCRIPTION
This is a quick fix for the Vicon Fast Bale stopping. Ideally, finding a specialization for this kind of baler and ignoring the stop logic would be best, but I could not find out easily. Only real change I have noticed is non-fast balers will move forward a few inches after unloading. This does not result in any missed swath. Fixes #5685 