### PR TITLE
fixes #5695 Fixing cotton baler

### DIFF
--- a/BalerAIDriver.lua
+++ b/BalerAIDriver.lua
@@ -73,7 +73,7 @@ function BalerAIDriver:handleBaler()
 			elseif self.baler.spec_baler.unloadingState ~= Baler.UNLOADING_CLOSED then
 				if fillLevel >= capacity then -- Only stop if capacity is full. Allowing for continuous balers such as the ViconFastBale
 					allowedToDrive = false
-				elseif fillLevel == 0 and self.baler.spec_baler.unloadingState == Baler.UNLOADING_CLOSING then
+				elseif fillLevel == 0 and (self.baler.spec_baler.unloadingState == Baler.UNLOADING_CLOSING or self.baler.spec_baler.unloadingState == Baler.UNLOADING_OPENING) then
 					allowedToDrive = false
 				elseif self.baler.spec_baler.unloadingState == Baler.UNLOADING_OPEN then
 					self.baler:setIsUnloadingBale(false)


### PR DESCRIPTION
Cotton baler switches states earlier than normal balers.
This should allow for no skipped cotton patches.

Fixes #5695 

Not the prettiest fix, but it should work.