### PR TITLE
Avoid unnecessary implement raise when transitioning from the connecting track

### DIFF
--- a/FieldworkAIDriver.lua
+++ b/FieldworkAIDriver.lua
@@ -550,7 +550,7 @@ function FieldworkAIDriver:onWaypointPassed(ix)
 			-- check for transition to connecting track, make sure we've been on it for a few waypoints already
 			-- to avoid raising the implements too soon, this can be a problem with long implements not yet reached
 			-- the end of the headland track while the tractor is already on the connecting track
-			if self.course:isOnConnectingTrack(ix) and self.course:isOnConnectingTrack(ix - 2) then
+			if self.course:isOnConnectingTrack(self.course:getCurrentWaypointIx()) and self.course:isOnConnectingTrack(ix) and self.course:isOnConnectingTrack(ix - 2) then
 				-- reached a connecting track (done with the headland, move to the up/down row or vice versa),
 				-- raise all implements while moving
 				self:debug('on a connecting track now, raising implements.')


### PR DESCRIPTION
This pull request fixes an unnecessary implement raise when the front of the vehicule has already transitioned from the connecting track but the end hasn't.
