### PR TITLE
diff Hud changes & added selectFillTypeSettingsList

### DIFF
--- a/AIDriver.lua
+++ b/AIDriver.lua
@@ -1789,3 +1789,18 @@ function AIDriver:checkProximitySensor(maxSpeed, allowedToDrive, moveForwards)
 	self:debugSparse('proximity: d = %.1f (%d %%), speed = %.1f', d, 100 * normalizedD, newSpeed)
 	return newSpeed, allowedToDrive
 end
+-- disable detachImplement while running AIDriver like GrainTransportAIDriver or CombineUnloadDriver
+function AIDriver:detachImplementByObject(superFunc,object, noEventSend)
+	local rootVehicle = self:getRootVehicle()
+	if rootVehicle and rootVehicle.cp and rootVehicle.cp.driver and rootVehicle.cp.driver:isActive() then 
+		return
+	end
+	return superFunc(self,object, noEventSend)
+end
+AttacherJoints.detachImplementByObject = Utils.overwrittenFunction(AttacherJoints.detachImplementByObject,AIDriver.detachImplementByObject)
+
+
+
+
+
+

--- a/AITurn.lua
+++ b/AITurn.lua
@@ -121,7 +121,7 @@ function AITurn.canMakeKTurn(vehicle, turnContext)
 		courseplay.debugVehicle(AITurn.debugChannel, vehicle, 'Not all attached implements allow for reversing, use generated course turn')
 		return false
 	end
-	if vehicle.cp.turnOnField and not AITurn.canTurnOnField(turnContext, vehicle) then
+	if vehicle.cp.settings.turnOnField:is(true) and not AITurn.canTurnOnField(turnContext, vehicle) then
 		courseplay.debugVehicle(AITurn.debugChannel, vehicle, 'Turn on field is on but there is not enough space, use generated course turn')
 		return false
 	end
@@ -534,7 +534,7 @@ end
 
 function CourseTurn:generateCalculatedTurn()
 	-- TODO: fix ugly dependency on global variables, there should be one function to create the turn maneuver
-	self.vehicle.cp.turnStage = 1
+	self.vehicle.cp.settings.turnStage:set(true)
 	-- call turn() with stage 1 which will generate the turn waypoints (dt isn't used by that part)
 	courseplay:turn(self.vehicle, 1, self.turnContext)
 	-- they waypoints should now be in turnTargets, create a course based on that
@@ -549,7 +549,7 @@ function CourseTurn:generatePathfinderTurn()
 	local done, path
 	local turnEndNode, startOffset, goalOffset = self.turnContext:getTurnEndNodeAndOffsets()
 	local canTurnOnField, distanceToReverse = AITurn.canTurnOnField(self.turnContext, self.vehicle)
-	if not canTurnOnField and self.vehicle.cp.turnOnField then
+	if not canTurnOnField and self.vehicle.cp.settings.turnOnField:is(true) then
 		self:debug('Turn on field is on, generating reverse course before turning.')
 		self.reverseBeforeStartingTurnWaypoints = self.turnContext:createReverseWaypointsBeforeStartingTurn(self.vehicle, distanceToReverse)
 		startOffset = startOffset - distanceToReverse

--- a/CombineAIDriver.lua
+++ b/CombineAIDriver.lua
@@ -872,7 +872,7 @@ function CombineAIDriver:startTurn(ix)
 			self:debug('Headland turn but this harvester uses normal turn maneuvers.')
 			self.turnType = self.turnTypes.HEADLAND_NORMAL
 			UnloadableFieldworkAIDriver.startTurn(self, ix)
-		elseif self.course:isOnOutermostHeadland(ix) and self.vehicle.cp.turnOnField then
+		elseif self.course:isOnOutermostHeadland(ix) and self.vehicle.cp.settings.turnOnField:is(true) then
 			self:debug('Creating a pocket in the corner so the combine stays on the field during the turn')
 			self.aiTurn = CombinePocketHeadlandTurn(self.vehicle, self, self.turnContext, self.fieldworkCourse)
 			self.turnType = self.turnTypes.HEADLAND_POCKET

--- a/CombineUnloadAIDriver.lua
+++ b/CombineUnloadAIDriver.lua
@@ -2077,7 +2077,7 @@ function CombineUnloadAIDriver:onBlockingOtherVehicle(blockedVehicle)
 		self:debug('Already busy moving out of the way')
 	end
 end
-
+--TODO maybe a new Setting for this one ??
 function CombineUnloadAIDriver:shiftCombinesList(change_by)
 	self.combinesListHUDOffset = MathUtil.clamp(self.combinesListHUDOffset+ change_by,0,#self.vehicle.cp.possibleCombines-6)
 end

--- a/Generic/LinkedList.lua
+++ b/Generic/LinkedList.lua
@@ -1,0 +1,257 @@
+--This is a Generic First -> Last LinkedList
+--Courseplay Interface should be a LinkedListSetting
+
+LinkedList = CpObject()
+
+function LinkedList:init(...)
+	self.First = nil
+	self.count = -1
+	self:addToEmptyList(...)
+end
+
+LinkedNode = {}
+function LinkedNode:new(_next,_data)
+	local o = {}
+	o.Next = _next
+	o.data = _data
+	return o
+end
+
+--add methods
+function LinkedList:addLast(...)	
+	local node = self:iterateToEnd(self.First)
+	node.Next = LinkedNode:new(nil,...)
+	self:incrementCount()
+--	self:printLinkedList()
+end
+
+function LinkedList:addFirst(...)
+	local First = self.First.Next
+	local node = LinkedNode:new(First,...)
+	self.First.Next = node
+	self:incrementCount()
+--	self:printLinkedList()
+end
+
+--remove methos 
+function LinkedList:removeLast()
+	if self:isEmpty() then 
+		return false
+	end
+	local node = self:iterateByIndex(self.count-1)
+	local Last = node.Next
+	node.Next = nil
+	self:decrementCount()
+end
+
+function LinkedList:removeFirst()
+	if self:isEmpty() then 
+		return false
+	end
+	local node = self.First.Next
+	self.First.Next = node.Next
+	self:decrementCount()
+end
+
+function LinkedList:removeX(index)
+	if self:isEmpty() then 
+		return false
+	end
+	local preNode = self:getElementByIndex(index-1)
+	if preNode then 
+		local node = preNode.Next 
+		preNode.Next = node.Next
+		self:decrementCount()
+	else
+		self:removeFirst()
+	end
+--	self:printLinkedList()
+	return true
+end
+
+--shift Node methods
+function LinkedList:swapUpX(index)
+	local prePreNode = self:getElementByIndex(index-2)
+	if prePreNode then 
+		local preNode = prePreNode.Next
+		if preNode then
+			local node = preNode.Next
+			if node then 
+				local nextNode = node.Next 
+				prePreNode.Next = node
+				node.Next = preNode
+				preNode.Next = nextNode
+			end
+		end
+	else
+		local preNode = self:getElementByIndex(index-1)
+		if preNode then 
+			local node = preNode.Next
+			if node then 
+				local nextNode = node.Next
+				node.Next = preNode
+				preNode.Next = nextNode
+				self.First.Next = node
+			end
+		end
+	end
+--	self:printLinkedList()
+end
+
+function LinkedList:swapDownX(index)
+	local preNode = self:getElementByIndex(index-1)
+	if preNode then 
+		local node = preNode.Next
+		if node then
+			local nextNode = node.Next
+			if nextNode then 
+				local nextNextNode = nextNode.Next
+				preNode.Next = nextNode
+				nextNode.Next = node
+				node.Next = nextNextNode
+			end
+		end
+	else
+		--node = self.First.Next
+		local node = self:getElementByIndex(index)
+		if node then
+			local nextNode = node.Next
+			if nextNode then 
+				local nextNextNode = nextNode.Next
+				nextNode.Next = node
+				node.Next = nextNextNode
+				self.First.Next = nextNode
+			end
+		end
+	end
+--	self:printLinkedList()
+end
+
+--print List
+function LinkedList:printLinkedList()
+	if self:isEmpty() then 
+		return false
+	end	
+	local node = self.First.Next
+	index = 1
+	while node ~=nil do
+		self:printLinkedNode(node,index)
+		node = node.Next
+		index = index+1
+	end
+end
+
+--local helpers
+function LinkedList:addToEmptyList(...)
+	local node = LinkedNode:new(nil,self.First,...)
+	self.First=node
+	self:incrementCount()
+end
+
+function LinkedList:isEmpty()
+	if self.count > 0 then 
+		return false
+	else
+	--	print("LinkedList is empty!!!!!")
+		return true
+	end
+end
+
+function LinkedList:iterateBeforeX(X)
+	local node = self.First
+	while X.Prev ~= node do 
+		node = node.Next
+	end
+end
+
+function LinkedList:iterateAfterX(X)
+	local node = self.Last
+	while X.Next ~= node do 
+		node = node.Prev
+	end
+end
+
+function LinkedList:printLinkedNode(X,index)
+	if type(X.data) == "table" then
+		print(index..": ")
+		for _,value in pairs(X.data) do 
+			print("     ".._..": "..value)
+		end
+	else
+		print(index..": "..tostring(X.data))
+	end
+end
+
+function LinkedList:iterateByIndex(index)
+	if index <1 then 
+		return
+	end
+	
+	local node = self.First
+	i=1
+	for i=1,index do 
+		node = node.Next
+		
+		if node == nil then 
+			return
+		end
+	end
+	return node
+end
+
+function LinkedList:iterateToEnd(node)
+	while node.Next ~=nil do 
+		node=node.Next
+	end
+	return node
+end
+
+function LinkedList:incrementCount()
+	self.count = self.count+1
+end
+
+function LinkedList:decrementCount()
+	self.count = self.count-1
+end
+
+--getters
+function LinkedList:getFirst()
+	return self.First.Next
+end
+
+function LinkedList:getSize()
+	return self.count
+end
+
+function LinkedList:getElementByIndex(index)
+	return self:iterateByIndex(index)
+end
+
+function LinkedList:getDataXtoY(x,y)	
+	local node = self:iterateByIndex(x)
+	local totalData = {}
+	local i=x
+	while node ~=nil do 
+		totalData[i]=node.data
+		if i==y then
+			break 
+		end
+		node=node.Next
+		i=i+1
+	end
+	return totalData
+end
+
+
+function LinkedList:getData()
+	local node = self.First.Next
+	local totalData = {}
+	i=1
+	while node ~=nil do 
+	--	self:printLinkedNode(node,i)
+		totalData[i]=node.data
+		node=node.Next
+		i=i+1
+	end
+	return totalData
+end

--- a/base.lua
+++ b/base.lua
@@ -49,10 +49,8 @@ function courseplay:onLoad(savegame)
 	self.cp.mrHasStopped = nil -- Used in the turn manuver to stop MR on a steep grade
 
 	--turn maneuver
-	self.cp.turnOnField = true;
 	self.cp.oppositeTurnMode = false;
 	self.cp.waitForTurnTime = 0.00   --float
-	self.cp.turnStage = 0 --int
 	self.cp.aiTurnNoBackward = false --bool
 	self.cp.canBeReversed = nil --bool
 	self.cp.backMarkerOffset = nil --float
@@ -565,7 +563,6 @@ function courseplay:onLoad(savegame)
 	self.cp.settings:addSetting(AutomaticCoverHandlingSetting, self)
 	self.cp.settings:addSetting(AutomaticUnloadingOnFieldSetting, self)
 	self.cp.settings:addSetting(DriverPriorityUseFillLevelSetting, self)
-	self.cp.settings:addSetting(RunCounterMaxSetting, self)
 	self.cp.settings:addSetting(UseRecordingSpeedSetting, self)
 	self.cp.settings:addSetting(WarningLightsModeSetting, self)
 	self.cp.settings:addSetting(ShowMapHotspotSetting, self)
@@ -574,6 +571,9 @@ function courseplay:onLoad(savegame)
 	self.cp.settings:addSetting(RealisticDrivingSetting, self)
 	self.cp.settings:addSetting(DriveUnloadNowSetting, self)
 	self.cp.settings:addSetting(CombineWantsCourseplayerSetting, self)
+	self.cp.settings:addSetting(SiloSelectedFillTypeSetting, self)
+	self.cp.settings:addSetting(TurnOnFieldSetting, self)
+	self.cp.settings:addSetting(TurnStageSetting, self)
 	
 	---@type SettingsContainer
 	self.cp.courseGeneratorSettings = SettingsContainer()
@@ -1544,7 +1544,6 @@ function courseplay:loadVehicleCPSettings(xmlFile, key, resetVehicles)
 	
 		-- MODES 4 / 6
 		curKey = key .. '.courseplay.fieldWork';
-		self.cp.turnOnField							= Utils.getNoNil( getXMLBool(xmlFile, curKey .. '#turnOnField'),			true);
 		self.cp.oppositeTurnMode					= Utils.getNoNil( getXMLBool(xmlFile, curKey .. '#oppositeTurnMode'),		false);
 		self.cp.workWidth 							= Utils.getNoNil(getXMLFloat(xmlFile, curKey .. '#workWidth'),				3);
 		self.cp.ridgeMarkersAutomatic				= Utils.getNoNil( getXMLBool(xmlFile, curKey .. '#ridgeMarkersAutomatic'),	true);
@@ -1711,7 +1710,6 @@ function courseplay:saveToXMLFile(xmlFile, key, usedModNames)
 	setXMLString(xmlFile, newKey..".fieldWork #offsetData", offsetData)
 	setXMLInt(xmlFile, newKey..".fieldWork #abortWork", Utils.getNoNil(self.cp.abortWork, 0))
 	setXMLInt(xmlFile, newKey..".fieldWork #refillUntilPct", self.cp.refillUntilPct)
-	setXMLBool(xmlFile, newKey..".fieldWork #turnOnField", self.cp.turnOnField)
 	setXMLBool(xmlFile, newKey..".fieldWork #oppositeTurnMode", self.cp.oppositeTurnMode)
 	setXMLString(xmlFile, newKey..".fieldWork #manualWorkWidth", string.format("%.1f",Utils.getNoNil(self.cp.manualWorkWidth,0)))
 	setXMLString(xmlFile, newKey..".fieldWork #lastValidTipDistance", string.format("%.1f",Utils.getNoNil(self.cp.lastValidTipDistance,0)))

--- a/course-generator/PathfinderUtil.lua
+++ b/course-generator/PathfinderUtil.lua
@@ -526,7 +526,7 @@ function PathfinderUtil.findPathForTurn(vehicle, startOffset, goalReferenceNode,
 
     local fieldNum = courseplay.fields:onWhichFieldAmI(vehicle)
     PathfinderUtil.setUpVehicleCollisionData(vehicle, vehiclesToIgnore)
-    local parameters = PathfinderUtil.Parameters(nil, vehicle.cp.turnOnField and 10 or nil, false)
+    local parameters = PathfinderUtil.Parameters(nil, vehicle.cp.settings.turnOnField:is(true) and 10 or nil, false)
     local context = PathfinderUtil.Context(PathfinderUtil.VehicleData(vehicle, true, 0.2), PathfinderUtil.FieldData(fieldNum), parameters, vehiclesToIgnore)
     local done, path = pathfinder:start(start, goal, turnRadius, context, allowReverse, PathfinderUtil.getNodePenalty, PathfinderUtil.isValidNode, PathfinderUtil.isValidAnalyticSolutionNode)
     return pathfinder, done, path

--- a/courseplay.lua
+++ b/courseplay.lua
@@ -127,6 +127,7 @@ local function initialize()
 		'Events/StartStopWorkEvent',
 		'Events/UserConnectedEvent',
 		'Events/PostSyncEvent',
+		'Generic/LinkedList'
 	};
 
 	local numFiles, numFilesLoaded = #(fileList) + 2, 2; -- + 2 as 'register.lua', 'courseplay.lua' have already been loaded
@@ -344,8 +345,7 @@ local function setGlobalData()
 	[87]={name='self.cp.generationPosition.fieldNum',dataFormat='Int'},
 	[87]={name='self.cp.generationPosition.hasSavedPosition',dataFormat='Bool'},
 	[88]={name='self.cp.generationPosition.x',dataFormat='Float'},
-	[89]={name='self.cp.generationPosition.z',dataFormat='Float'},
-	[90]={name='self.cp.turnOnField',dataFormat='Bool'}
+	[89]={name='self.cp.generationPosition.z',dataFormat='Float'}
 	}
 
 	-- TODO: see where is the best to instantiate these settings. Maybe we need a container for all these

--- a/fruit.lua
+++ b/fruit.lua
@@ -240,7 +240,7 @@ function courseplay:sideToDrive(vehicle, combine, distance, switchSide)
 		courseplay:debug(string.format("%s:courseplay:sideToDrive: is Courseplayer", nameNum(combine)), 4);
 		local ridgeMarker = 0;
 		local wayPoint = tractor.cp.waypointIndex;
-		if tractor.cp.turnStage > 0 then
+		if tractor.cp.settings.turnStage:is(true) then
    			switchSide = true;
   		end;
 		if not switchSide then

--- a/gui/VehicleSettingsPage.lua
+++ b/gui/VehicleSettingsPage.lua
@@ -25,7 +25,7 @@ function VehicleSettingsPage:onFrameClose()
 	VehicleSettingsPage:superClass().onFrameClose(self);
 end;
 
-function VehicleSettingsPage:getSettings()
+function VehicleSettingsPage:getSettings()	
 	return g_currentMission.controlledVehicle.cp.settings
 end
 
@@ -55,7 +55,7 @@ end
 
 function VehicleSettingsPage:onClickOk()
 	for _, setting in pairs(self:getSettings()) do
-		if setting:getGuiElement() then
+		if setting.getGuiElement and setting:getGuiElement() then
 			setting:setToIx(setting:getGuiElement():getState())
 		end
 	end
@@ -63,7 +63,9 @@ end
 
 function VehicleSettingsPage:onClickReset()
 	for _, setting in pairs(self:getSettings()) do
-		setting:getGuiElement():setState(setting:getGuiElementState(), false)
+		if setting.getGuiElement then
+			setting:getGuiElement():setState(setting:getGuiElementState(), false)
+		end
 	end
 end
 
@@ -84,7 +86,7 @@ end
 
 function VehicleSettingsPage:updateMyGUISettings()
 	for _, setting in pairs(self:getSettings()) do
-		if setting:getGuiElement() then
+		if setting.getGuiElement and setting:getGuiElement() then
 			setting:getGuiElement():setState(setting:getGuiElementState(), false)
 		end
 	end

--- a/hud.lua
+++ b/hud.lua
@@ -462,27 +462,7 @@ function courseplay.hud:setContent(vehicle)
 		vehicle.cp.hud.content.bottomInfo.convoyText = nil
 	end	
 		
-	if vehicle.cp.settings.runCounterMax:getIsRunCounterActive() and vehicle.cp.canDrive and vehicle.cp.driver.runCounter then
-		if vehicle.cp.siloSelectedFillType ~= nil and vehicle.cp.siloSelectedFillType ~= FillType.UNKNOWN then
-			vehicle.cp.hud.content.bottomInfo.runCounterText = g_fillTypeManager:getFillTypeByIndex(vehicle.cp.siloSelectedFillType).title..string.format(": %d / %s",vehicle.cp.driver.runCounter,  vehicle.cp.settings.runCounterMax:get());
-		else
-			vehicle.cp.hud.content.bottomInfo.runCounterText = courseplay:loc('UNKNOWN')..string.format(": %d / %s",vehicle.cp.driver.runCounter, vehicle.cp.settings.runCounterMax:get());
-		end
-	else
-		vehicle.cp.hud.content.bottomInfo.runCounterText = nil 
-	end
-	
-	
-	if vehicle.cp.hud.content.bottomInfo.runCounterText ~= nil then
-		local maxLength = 38
-		local courseNameLength = string.len(vehicle.cp.hud.content.bottomInfo.courseNameText)
-		local runCounterLength = string.len(vehicle.cp.hud.content.bottomInfo.runCounterText)
-		if courseNameLength + runCounterLength > maxLength then
-			local maxValidLength = maxLength-runCounterLength-3
-			vehicle.cp.hud.content.bottomInfo.courseNameText = string.sub(vehicle.cp.hud.content.bottomInfo.courseNameText,1, maxValidLength).."..."
-		end	
-	end
-	
+
 	------------------------------------------------------------------
 
 	-- AUTOMATIC PAGE RELOAD BASED ON VARIABLE STATE
@@ -676,10 +656,7 @@ function courseplay.hud:renderHudBottomInfo(vehicle)
 		renderText(self.bottomInfo.additionalContentX, self.bottomInfo.textPosY, self.fontSizes.bottomInfo, vehicle.cp.hud.content.bottomInfo.convoyText);
 	end
 	
-	if vehicle.cp.hud.content.bottomInfo.runCounterText ~= nil  then
-		courseplay:setFontSettings('white', false, 'right');
-		renderText(self.bottomInfo.additionalContentX, self.bottomInfo.textPosY, self.fontSizes.bottomInfo, vehicle.cp.hud.content.bottomInfo.runCounterText);
-	end
+	
 	
 end
 
@@ -731,41 +708,46 @@ function courseplay.hud:updatePageContent(vehicle, page)
 					else
 						self:disableButtonWithFunction(vehicle,page, 'cancelWait')
 					end				
-				elseif entry.functionToCall == 'changeStartAtPoint' then
+				elseif entry.functionToCall == 'Setting:startingPoint:next' then
+					--StartingPointSetting
 					if not vehicle:getIsCourseplayDriving() and vehicle.cp.canDrive then
-						self:enableButtonWithFunction(vehicle,page, 'changeStartAtPoint')
+						self:enableButtonWithFunction(vehicle,page, 'Setting:startingPoint:next')
 						vehicle.cp.hud.content.pages[page][line][1].text = vehicle.cp.settings.startingPoint:getLabel()
 						vehicle.cp.hud.content.pages[page][line][2].text = vehicle.cp.settings.startingPoint:getText()
 					else
-						self:disableButtonWithFunction(vehicle,page, 'changeStartAtPoint')
+						self:disableButtonWithFunction(vehicle,page, 'Setting:startingPoint:next')
 					end				
-				elseif entry.functionToCall == 'setStopAtEnd' then
+				elseif entry.functionToCall == 'Setting:stopAtEnd:toggle' then
+					--StopAtEndSetting
 					if vehicle.cp.canDrive then
-						self:enableButtonWithFunction(vehicle,page, 'setStopAtEnd')
+						self:enableButtonWithFunction(vehicle,page, 'Setting:stopAtEnd:toggle')
 						vehicle.cp.hud.content.pages[page][line][1].text = vehicle.cp.settings.stopAtEnd:getLabel()
 						vehicle.cp.hud.content.pages[page][line][2].text = vehicle.cp.settings.stopAtEnd:getText() 
 					else
-						self:disableButtonWithFunction(vehicle,page, 'setStopAtEnd')
+						self:disableButtonWithFunction(vehicle,page, 'Setting:stopAtEnd:toggle')
 					end
-				elseif entry.functionToCall == 'toggleReturnToFirstPoint' then
+				elseif entry.functionToCall == 'Setting:returnToFirstPoint:toggle' then
+					--ReturnToFirstPointSetting 
 					if vehicle.cp.canDrive then
-						self:enableButtonWithFunction(vehicle,page, 'toggleReturnToFirstPoint')
+						self:enableButtonWithFunction(vehicle,page, 'Setting:returnToFirstPoint:toggle')
 						self:disableButtonWithFunction(vehicle,page, 'setCustomSingleFieldEdge')
 						vehicle.cp.hud.content.pages[page][line][1].text = vehicle.cp.settings.returnToFirstPoint:getLabel()
 						vehicle.cp.hud.content.pages[page][line][2].text = vehicle.cp.settings.returnToFirstPoint:getText()
 					else
-						self:disableButtonWithFunction(vehicle,page, 'toggleReturnToFirstPoint')
+						self:disableButtonWithFunction(vehicle,page, 'Setting:returnToFirstPoint:toggle')
 						forceUpdate = true -- force reload of this page if functionToCall changed
 						entry.functionToCall = 'setCustomSingleFieldEdge'
 						self:enableButtonWithFunction(vehicle,page, 'setCustomSingleFieldEdge')
 						courseplay.hud:setReloadPageOrder(vehicle, page, true);
 
 					end
-				elseif entry.functionToCall == 'toggleAutomaticCoverHandling' then
+				elseif entry.functionToCall == 'Setting:automaticCoverHandling:toggle' then
+					--AutomaticCoverHandlingSetting
 					vehicle.cp.hud.content.pages[page][line][1].text = vehicle.cp.settings.automaticCoverHandling:getLabel()
 					vehicle.cp.hud.content.pages[page][line][2].text = vehicle.cp.settings.automaticCoverHandling:getText()
 				
 				elseif entry.functionToCall == 'changeSiloFillType' then
+					--old code !!
 					if vehicle.cp.siloSelectedFillType ~= nil then 
 						self:enableButtonWithFunction(vehicle,page, 'changeSiloFillType')
 						vehicle.cp.hud.content.pages[page][line][1].text = courseplay:loc('COURSEPLAY_FARM_SILO_FILL_TYPE');
@@ -773,24 +755,15 @@ function courseplay.hud:updatePageContent(vehicle, page)
 					else
 						self:disableButtonWithFunction(vehicle,page, 'changeSiloFillType')
 					end
-				elseif entry.functionToCall == 'changemaxRunNumber' then
-					if vehicle.cp.canDrive then
-						self:enableButtonWithFunction(vehicle,page, 'changemaxRunNumber')
-						vehicle.cp.hud.content.pages[page][line][1].text = vehicle.cp.settings.runCounterMax:getLabel()
-						vehicle.cp.hud.content.pages[page][line][2].text = vehicle.cp.settings.runCounterMax:getText()
+				elseif entry.functionToCall == 'Setting:siloSelectedFillType:addFilltype' then
+					--SiloSelectedFillTypeSetting
+					if not vehicle.cp.settings.siloSelectedFillType:isFull() then 
+						self:enableButtonWithFunction(vehicle,page, 'changeSiloFillType')
+						vehicle.cp.hud.content.pages[page][line][1].text = vehicle.cp.settings.siloSelectedFillType:getLabel()
 					else
-						self:disableButtonWithFunction(vehicle,page, 'changemaxRunNumber')
+						self:disableButtonWithFunction(vehicle,page, 'changeSiloFillType')
 					end
-					
-				elseif entry.functionToCall == 'resetRunCounter' then
-					if vehicle.cp.canDrive and vehicle.cp.settings.runCounterMax:getIsRunCounterActive() then
-						self:enableButtonWithFunction(vehicle,page, 'resetRunCounter')
-						vehicle.cp.hud.content.pages[page][line][1].text = courseplay:loc('COURSEPLAY_RESET_NUMBER_OF_RUNS') ;
-					else
-						self:disableButtonWithFunction(vehicle,page, 'resetRunCounter')
-					end
-					
-					
+					self:updateSiloSelectedFillTypeList(vehicle,page,3,7)					
 				elseif entry.functionToCall == 'switchDriverCopy' then
 					if not vehicle.cp.canDrive and not vehicle.cp.isRecording and not vehicle.cp.recordingIsPaused then
 						self:enableButtonWithFunction(vehicle,page, 'switchDriverCopy')
@@ -843,21 +816,26 @@ function courseplay.hud:updatePageContent(vehicle, page)
 						vehicle.cp.hud.content.pages[page][line][1].text = courseplay:loc('COURSEPLAY_SPEED_MAX');
 						vehicle.cp.hud.content.pages[page][line][2].text = streetSpeedStr
 					end
-				elseif entry.functionToCall == 'toggleUseRecordingSpeed' then
+				elseif entry.functionToCall == 'Setting:useRecordingSpeed:toggle' then
+					--UseRecordingSpeedSetting
 					vehicle.cp.hud.content.pages[page][line][1].text = vehicle.cp.settings.useRecordingSpeed:getLabel()
 					vehicle.cp.hud.content.pages[page][line][2].text = vehicle.cp.settings.useRecordingSpeed:getText() 
-				elseif entry.functionToCall == 'changeWarningLightsMode' then
+				elseif entry.functionToCall == 'Setting:warningLightsMode:next' then
+					--WarningLightsModeSetting
 					vehicle.cp.hud.content.pages[page][line][1].text = vehicle.cp.settings.warningLightsMode:getLabel()
 					vehicle.cp.hud.content.pages[page][line][2].text = vehicle.cp.settings.warningLightsMode:getText() 
-				elseif entry.functionToCall == 'toggleIngameMapIconShowText' then
+				elseif entry.functionToCall == 'Setting:showMapHotspot:next' then
+					--ShowMapHotspotSetting 
 					vehicle.cp.hud.content.pages[page][line][1].text = vehicle.cp.settings.showMapHotspot:getLabel()
 					vehicle.cp.hud.content.pages[page][line][2].text = vehicle.cp.settings.showMapHotspot:getText() 
 				elseif entry.functionToCall == 'openAdvancedSettingsDialog' then
 					vehicle.cp.hud.content.pages[page][line][1].text = courseplay:loc('COURSEPLAY_OPEN_ADVANCED_SETTINGS');
-				elseif entry.functionToCall == 'toggleFuelSaveOption' then
+				elseif entry.functionToCall == 'Setting:saveFuelOption:toggle' then
+					--SaveFuelOptionSetting
 					vehicle.cp.hud.content.pages[page][line][1].text = vehicle.cp.settings.saveFuelOption:getLabel()
 					vehicle.cp.hud.content.pages[page][line][2].text = vehicle.cp.settings.saveFuelOption:getText() 
-				elseif entry.functionToCall == 'toggleAutoRefuel' then
+				elseif entry.functionToCall == 'Setting:allwaysSearchFuel:toggle' then
+					--AllwaysSearchFuelSetting
 					vehicle.cp.hud.content.pages[page][line][1].text = vehicle.cp.settings.allwaysSearchFuel:getLabel()
 					vehicle.cp.hud.content.pages[page][line][2].text = vehicle.cp.settings.allwaysSearchFuel:getText()
 				elseif entry.functionToCall == 'changeLoadUnloadOffsetX' then
@@ -875,7 +853,8 @@ function courseplay.hud:updatePageContent(vehicle, page)
 					else
 						vehicle.cp.hud.content.pages[page][line][2].text = '---';
 					end;
-				elseif entry.functionToCall == 'toggleRealisticDriving' then
+				elseif entry.functionToCall == 'Setting:useRealisticDriving:toggle' then
+					--RealisticDrivingSetting
 					vehicle.cp.hud.content.pages[page][line][1].text = vehicle.cp.settings.useRealisticDriving:getLabel()
 					vehicle.cp.hud.content.pages[page][line][2].text = vehicle.cp.settings.useRealisticDriving:getText()
 
@@ -920,12 +899,10 @@ function courseplay.hud:updatePageContent(vehicle, page)
 						self:disableButtonWithFunction(vehicle,page, 'changeLaneOffset')	
 					end
 				
-				elseif entry.functionToCall == 'toggleTurnOnField' then
-					vehicle.cp.hud.content.pages[page][line][1].text = courseplay:loc('COURSEPLAY_TURN_ON_FIELD');
-					vehicle.cp.hud.content.pages[page][line][2].text = vehicle.cp.turnOnField and courseplay:loc('COURSEPLAY_ACTIVATED') or courseplay:loc('COURSEPLAY_DEACTIVATED');
-	
-	
-	
+				elseif entry.functionToCall == 'Setting:turnOnField:toggle' then
+					--TurnOnFieldSetting
+					vehicle.cp.hud.content.pages[page][line][1].text = vehicle.cp.settings.turnOnField:getLabel()
+					vehicle.cp.hud.content.pages[page][line][2].text = vehicle.cp.settings.turnOnField:getText()
 				elseif entry.functionToCall == 'setCustomSingleFieldEdge' then
 					if not vehicle.cp.fieldEdge.customField.isCreated 
 					and not vehicle:getIsCourseplayDriving() 
@@ -933,13 +910,13 @@ function courseplay.hud:updatePageContent(vehicle, page)
 					and not vehicle.cp.isRecording 
 					and not vehicle.cp.recordingIsPaused then
 						self:enableButtonWithFunction(vehicle,page, 'setCustomSingleFieldEdge')
-						self:disableButtonWithFunction(vehicle,page, 'toggleReturnToFirstPoint')
+						self:disableButtonWithFunction(vehicle,page, 'Setting:returnToFirstPoint:toggle')
 						vehicle.cp.hud.content.pages[page][line][1].text = courseplay:loc('COURSEPLAY_SCAN_CURRENT_FIELD_EDGES');
 					else
 						self:disableButtonWithFunction(vehicle,page, 'setCustomSingleFieldEdge')
 						forceUpdate = true -- force reload of this page if functionToCall changed
-						entry.functionToCall = 'toggleReturnToFirstPoint'
-						self:enableButtonWithFunction(vehicle, page, 'toggleReturnToFirstPoint')
+						entry.functionToCall = 'Setting:returnToFirstPoint:toggle'
+						self:enableButtonWithFunction(vehicle, page, 'Setting:returnToFirstPoint:toggle')
 						courseplay.hud:setReloadPageOrder(vehicle, page, true);
 					end
 				elseif entry.functionToCall == 'setCustomFieldEdgePathNumber' then
@@ -971,8 +948,8 @@ function courseplay.hud:updatePageContent(vehicle, page)
 					else
 						self:disableButtonWithFunction(vehicle,page, 'addCustomSingleFieldEdgeToList')
 					end
-				elseif entry.functionToCall == 'toggleSymmetricLaneChange' then
-					--Symmetrical lane change
+				elseif entry.functionToCall == 'Setting:symmetricLaneChange:toggle' then
+					--SymmetricLaneChangeSetting
 					vehicle.cp.hud.content.pages[page][line][1].text = vehicle.cp.settings.symmetricLaneChange:getLabel()
 					if vehicle.cp.laneOffset ~= 0 then
 						vehicle.cp.hud.content.pages[page][line][2].text = vehicle.cp.settings.symmetricLaneChange:getText()
@@ -1056,9 +1033,10 @@ function courseplay.hud:updatePageContent(vehicle, page)
 						end
 					end
 
-				elseif entry.functionToCall == 'toggleWantsCourseplayer' then
+				elseif entry.functionToCall == 'Setting:combineWantsCourseplayer:toggle' then
+					--CombineWantsCourseplayerSetting 
 					if not g_combineUnloadManager:getHasUnloaders(vehicle)  then
-						self:enableButtonWithFunction(vehicle,page, 'toggleWantsCourseplayer')
+						self:enableButtonWithFunction(vehicle,page, 'Setting:combineWantsCourseplayer:toggle')
 						if vehicle.cp.settings.combineWantsCourseplayer:is(true) then
 							vehicle.cp.hud.content.pages[page][line][1].text = vehicle.cp.settings.combineWantsCourseplayer:getText()
 						else
@@ -1066,7 +1044,7 @@ function courseplay.hud:updatePageContent(vehicle, page)
 						end
 					else
 						local courseplayer = g_combineUnloadManager:getUnloaderByNumber(1, vehicle)
-						self:disableButtonWithFunction(vehicle,page, 'toggleWantsCourseplayer')
+						self:disableButtonWithFunction(vehicle,page, 'Setting:combineWantsCourseplayer:toggle')
 						vehicle.cp.hud.content.pages[page][line][1].text =  vehicle.cp.settings.combineWantsCourseplayer:getLabel()
 						vehicle.cp.hud.content.pages[page][line][2].text =  courseplayer.name;
 					end
@@ -1106,27 +1084,26 @@ function courseplay.hud:updatePageContent(vehicle, page)
 						self:disableButtonWithFunction(vehicle,page, 'switchCourseplayerSide')
 					end
 			
-				elseif entry.functionToCall == 'toggleTurnStage' then
+				elseif entry.functionToCall == 'Setting:turnStage:toggle' then
+					--TurnStageSetting
 					if g_combineUnloadManager:getHasUnloaders(vehicle) then
 						--manual chopping: initiate/end turning maneuver
 						if not  vehicle:getIsCourseplayDriving()  then
-							self:enableButtonWithFunction(vehicle,page, 'toggleTurnStage')
-							vehicle.cp.hud.content.pages[page][line][1].text = courseplay:loc('COURSEPLAY_TURN_MANEUVER');
-							if vehicle.cp.turnStage == 0 then
-								vehicle.cp.hud.content.pages[page][line][2].text = courseplay:loc('COURSEPLAY_START');
-							elseif vehicle.cp.turnStage == 1 then
-								vehicle.cp.hud.content.pages[page][line][2].text = courseplay:loc('COURSEPLAY_FINISH');
-							end;
-						end;
+							self:enableButtonWithFunction(vehicle,page, 'Setting:turnStage:toggle')
+							vehicle.cp.hud.content.pages[page][line][1].text = vehicle.cp.settings.turnStage:getLabel()
+							vehicle.cp.hud.content.pages[page][line][2].text = vehicle.cp.settings.turnStage:getText()
+						end
 					else
-						self:disableButtonWithFunction(vehicle,page, 'toggleTurnStage')
+						self:disableButtonWithFunction(vehicle,page, 'Setting:turnStage:toggle')
 					end
 
-				elseif entry.functionToCall == 'toggleDriverPriority' then
+				elseif entry.functionToCall == 'Setting:driverPriorityUseFillLevel:toggle' then
+					--DriverPriorityUseFillLevelSetting 
 					vehicle.cp.hud.content.pages[page][line][1].text = vehicle.cp.settings.driverPriorityUseFillLevel:getLabel()
 					vehicle.cp.hud.content.pages[page][line][2].text = vehicle.cp.settings.driverPriorityUseFillLevel:getText() 
 
-				elseif entry.functionToCall == 'toggleStopWhenUnloading' then
+				elseif entry.functionToCall == 'Setting:stopForUnload:toggle' then
+					--StopForUnloadSetting
 					vehicle.cp.hud.content.pages[page][line][1].text = vehicle.cp.settings.stopForUnload:getLabel()
 					vehicle.cp.hud.content.pages[page][line][2].text = vehicle.cp.settings.stopForUnload:getText()
 		
@@ -1193,6 +1170,7 @@ function courseplay.hud:updatePageContent(vehicle, page)
 					end;
 				]]
 				elseif entry.functionToCall == 'setSearchCombineOnField' then 
+					--SearchCombineOnFieldSetting
 					--Line 3: choose field for automatic search --only if automatic
 					if vehicle.cp.searchCombineAutomatically and courseplay.fields.numAvailableFields > 0 then
 						vehicle.cp.settings.searchCombineOnField:refresh()
@@ -1223,13 +1201,15 @@ function courseplay.hud:updatePageContent(vehicle, page)
 					vehicle.cp.hud.content.pages[page][line][1].text = courseplay:loc('COURSEPLAY_REFILL_UNTIL_PCT');
 					vehicle.cp.hud.content.pages[page][line][2].text = ('%d%%'):format(vehicle.cp.refillUntilPct);
 							
-				elseif entry.functionToCall == 'toggleAutomaticUnloadingOnField' then
+				elseif entry.functionToCall == 'Setting:automaticUnloadingOnField:toggle' then
+					--not used right now!
+					--AutomaticUnloadingOnFieldSetting 
 					if not vehicle.cp.hasUnloadingRefillingCourse then
-						self:enableButtonWithFunction(vehicle,page, 'toggleAutomaticUnloadingOnField')
+						self:enableButtonWithFunction(vehicle,page, 'Setting:automaticUnloadingOnField:toggle')
 						vehicle.cp.hud.content.pages[page][line][1].text = vehicle.cp.settings.automaticUnloadingOnField:getLabel() 
 						vehicle.cp.hud.content.pages[page][line][2].text = vehicle.cp.settings.automaticUnloadingOnField:getText() 
 					else
-						self:disableButtonWithFunction(vehicle,page, 'toggleAutomaticUnloadingOnField')
+						self:disableButtonWithFunction(vehicle,page, 'Setting:automaticUnloadingOnField:toggle')
 					end
 				elseif entry.functionToCall == 'toggleShovelStopAndGo' then
 					vehicle.cp.hud.content.pages[page][1][1].text = courseplay:loc('COURSEPLAY_SHOVEL_LOADING_POSITION');
@@ -1868,7 +1848,7 @@ function courseplay.hud:setupCombinesListPageButtons(vehicle,page)
 		width = self.buttonCoursesPosX[4] - self.contentMinX,
 		height = self.linesPosY[3] + self.lineHeight - self.linesPosY[self.numLines]
 	};
-	vehicle.cp.hud.combinesListMouseArea= courseplay.button:new(vehicle, 'global', nil, 'shiftCombinesList', -1, combinesListMouseWheelArea.x, combinesListMouseWheelArea.y, combinesListMouseWheelArea.width, combinesListMouseWheelArea.height, nil, -self.numLines, true, true);
+	vehicle.cp.hud.combinesListMouseArea= courseplay.button:new(vehicle, 'global', nil, 'AIDriver:shiftCombinesList', -1, combinesListMouseWheelArea.x, combinesListMouseWheelArea.y, combinesListMouseWheelArea.width, combinesListMouseWheelArea.height, nil, -self.numLines, true, true);
 	print("vehicle.cp.hud.combinesListMouseArea: "..tostring(vehicle.cp.hud.combinesListMouseArea))
 end
 
@@ -1982,6 +1962,20 @@ function courseplay.hud:setupShovelModeButtons(vehicle, pg)
 	--END Page 9
 end
 
+function courseplay.hud:setupSiloSelectedFillTypeList(vehicle,funct, hudPage,startLine,stopLine, column)
+	funct = "Setting:"..funct
+	self:debug(vehicle,"  setupSiloSelectedFillTypeList: "..tostring(funct))
+	local diff = startLine-1
+	for i=startLine,stopLine do 
+		courseplay.button:new(vehicle, hudPage, { 'iconSprite.png', 'navUp' }, funct..":moveUpByIndex",   i-diff, self.buttonPosX[3], self.linesButtonPosY[i], self.buttonSize.small.w, self.buttonSize.small.h, i, -5, false);
+		courseplay.button:new(vehicle, hudPage, { 'iconSprite.png', 'navDown' },  funct..":moveDownByIndex",    i-diff, self.buttonPosX[2], self.linesButtonPosY[i], self.buttonSize.small.w, self.buttonSize.small.h, i,  5, false);
+		courseplay.button:new(vehicle, hudPage, { 'iconSprite.png', 'delete' },  funct..":deleteByIndex",    i-diff, self.buttonPosX[1], self.linesButtonPosY[i], self.buttonSize.small.w, self.buttonSize.small.h, i,  5, false);
+		courseplay.button:new(vehicle, hudPage, { 'iconSprite.png', 'navMinus' }, funct..":decrementRunCounter",   i-diff, self.buttonPosX[5], self.linesButtonPosY[i], self.buttonSize.small.w, self.buttonSize.small.h, line, -5, false);
+		courseplay.button:new(vehicle, hudPage, { 'iconSprite.png', 'navPlus' },  funct..":incrementRunCounter",   i-diff, self.buttonPosX[4], self.linesButtonPosY[i], self.buttonSize.small.w, self.buttonSize.small.h, line,  5, false);
+	--	courseplay.button:new(vehicle, hudPage, nil, funct, 1, self.contentMinX, self.linesButtonPosY[line], self.contentMaxWidth, self.lineHeight, line, 5, true, true);
+		--vehicle.cp.hud.content.pages[hudPage][i][column].functionToCall = funct
+	end
+end
 
 --update functions 
 function courseplay.hud:updateCourseList(vehicle, page)
@@ -2129,6 +2123,30 @@ function courseplay.hud:updateSaveButtonActive(vehicle,state,active,page)
 	end
 end
 
+function courseplay.hud:updateSiloSelectedFillTypeList(vehicle,page,startLine,stopLine)
+	--text 
+	local diff = startLine-1
+	for i= startLine, stopLine do
+		vehicle.cp.hud.content.pages[page][i][1].text = vehicle.cp.settings.siloSelectedFillType:getText(i-diff)
+		vehicle.cp.hud.content.pages[page][i][2].text = vehicle.cp.settings.siloSelectedFillType:getRunCounterText(i-diff)
+	end
+	--button
+	for _,button in pairs(vehicle.cp.buttons[page]) do
+		local found = string.find(button.functionToCall, "siloSelectedFillType")
+		local foundAddButton = string.find(button.functionToCall, "addFilltype")
+		if found and not foundAddButton then 
+			local size = vehicle.cp.settings.siloSelectedFillType:getSize()
+			if button.parameter <=size then 
+				button:setDisabled(false)
+				button:setShow(true)
+			else
+				button:setDisabled(true)
+				button:setShow(false)
+			end
+		end
+	end
+end
+
 function courseplay.hud:showShiftHudButtons(vehicle, show)
 	local previousLine, nextLine
 	if show then
@@ -2268,8 +2286,8 @@ function courseplay.hud:setAIDriverContent(vehicle)
 	self:addRowButton(vehicle,'startStop', 1, 1, 1 )
 	self:addRowButton(vehicle,'start_record', 1, 1, 2 )
 	self:addRowButton(vehicle,'cancelWait', 1, 2, 1 )
-	self:addRowButton(vehicle,'changeStartAtPoint', 1, 2, 2 ):setOnlyCallLocal();
-	self:addRowButton(vehicle,'setStopAtEnd', 1, 3, 1 )
+	self:addRowButton(vehicle,'Setting:startingPoint:next', 1, 2, 2 )
+	self:addRowButton(vehicle,'Setting:stopAtEnd:toggle', 1, 3, 1 )
 	self:addSettingsRowWithArrows(vehicle,'switchDriverCopy', 1, 3, 2 )
 	self:setupCopyCourseButton(vehicle, 1, 3)
 	
@@ -2284,23 +2302,23 @@ function courseplay.hud:setAIDriverContent(vehicle)
 	self:addSettingsRow(vehicle,'changeFieldSpeed', 5, 2, 1 )
 	self:addSettingsRow(vehicle,'changeReverseSpeed', 5, 3, 1 )
 	self:addSettingsRow(vehicle,'changeMaxSpeed', 5, 4, 1 ) 
-	self:addRowButton(vehicle,'toggleUseRecordingSpeed', 5, 5, 1 ) 
+	self:addRowButton(vehicle,'Setting:useRecordingSpeed:toggle', 5, 5, 1 ) 
 	
 	
 	--page 6 general settings
 	self:enablePageButton(vehicle, 6)
 	self:setupDebugButtons(vehicle, 6)
 	self:setupShowWaypointsButtons(vehicle, 6, 3)
-	self:addRowButton(vehicle,'toggleIngameMapIconShowText', 6, 4, 1 )
+	self:addRowButton(vehicle,'Setting:showMapHotspot:next', 6, 4, 1 )
 	self:addRowButton(vehicle,'openAdvancedSettingsDialog', 6, 5, 1 ):setOnlyCallLocal()
 
 
 	--page 7 driving settings
 	self:enablePageButton(vehicle, 7)
-	self:addSettingsRow(vehicle,'changeWarningLightsMode', 7, 1, 1 )
-	self:addRowButton(vehicle,'toggleFuelSaveOption', 7, 2, 1 )
-	self:addRowButton(vehicle,'toggleAutoRefuel', 7, 3, 1 )
-	self:addRowButton(vehicle,'toggleAutomaticCoverHandling', 7, 4, 1 )
+	self:addSettingsRow(vehicle,'Setting:warningLightsMode:next', 7, 1, 1 )
+	self:addRowButton(vehicle,'Setting:saveFuelOption:toggle', 7, 2, 1 )
+	self:addRowButton(vehicle,'Setting:allwaysSearchFuel:toggle', 7, 3, 1 )
+	self:addRowButton(vehicle,'Setting:automaticCoverHandling:toggle', 7, 4, 1 )
 	self:addSettingsRow(vehicle,'changeWaitTime', 7, 5, 1 )
 	
 	self:setReloadPageOrder(vehicle, -1, true)
@@ -2310,15 +2328,13 @@ function courseplay.hud:setGrainTransportAIDriverContent(vehicle)
 	self:debug(vehicle,"setGrainTransportAIDriverContent")
 	--page 1 driving
 	self:addRowButton(vehicle,'setDriveNow', 1, 2, 3 )
-	
-	self:addSettingsRow(vehicle,'changemaxRunNumber', 1, 5, 1 )
-	self:addRowButton(vehicle,'resetRunCounter', 1, 6, 1 )
-	
-	
-	--page 1 driving
+
+	--page 3 
 	self:enablePageButton(vehicle, 3)
-	self:addSettingsRowWithArrows(vehicle,'changeSiloFillType', 3, 1, 1 )
-	self:addSettingsRowWithArrows(vehicle,'changeRefillUntilPct', 3, 2, 1 )
+	self:addSettingsRowWithArrows(vehicle,'changeRefillUntilPct', 3, 1, 1 )
+
+	self:addRowButton(vehicle,'Setting:siloSelectedFillType:addFilltype', 3, 2, 1 )
+	self:setupSiloSelectedFillTypeList(vehicle,'siloSelectedFillType', 3, 3, 7, 1)
 
 	--page 7 
 	self:addSettingsRow(vehicle,'changeLoadUnloadOffsetX', 7, 5, 1 )
@@ -2337,7 +2353,7 @@ function courseplay.hud:setFieldWorkAIDriverContent(vehicle)
 	self:setupCustomFieldEdgeButtons(vehicle,1,5)
 	self:addRowButton(vehicle,'addCustomSingleFieldEdgeToList', 1, 6, 1 )
 	-- shown in place of the custom field row when a course is loaded
-	self:addRowButton(vehicle,'toggleReturnToFirstPoint', 1, 5, 1 ):setOnlyCallLocal()
+	self:addRowButton(vehicle,'Setting:returnToFirstPoint:toggle', 1, 5, 1 )
 
 	--page 3 settings
 	self:enablePageButton(vehicle, 3)
@@ -2357,9 +2373,9 @@ function courseplay.hud:setFieldWorkAIDriverContent(vehicle)
 	self:enablePageButton(vehicle, 8)
 	self:addSettingsRowWithArrows(vehicle,'changeLaneNumber', 8, 1, 1 )
 	self:addSettingsRowWithArrows(vehicle,'changeLaneOffset', 8, 1, 2 )
-	self:addRowButton(vehicle,'toggleSymmetricLaneChange', 8, 2, 1 ):setOnlyCallLocal();
-	self:addRowButton(vehicle,'toggleTurnOnField', 8, 3, 1 )
-	self:addRowButton(vehicle,'toggleRealisticDriving', 8, 4, 1 )
+	self:addRowButton(vehicle,'Setting:symmetricLaneChange:toggle', 8, 2, 1 )
+	self:addRowButton(vehicle,'Setting:turnOnField:toggle', 8, 3, 1 )
+	self:addRowButton(vehicle,'Setting:useRealisticDriving:toggle', 8, 4, 1 )
 	self:addSettingsRowWithArrows(vehicle,'changeToolOffsetX', 8, 5, 1 )
 	self:setupSetAutoToolOffsetXButton(vehicle,8,5)
 	self:addSettingsRowWithArrows(vehicle,'changeToolOffsetZ', 8, 6, 1 )
@@ -2382,15 +2398,15 @@ function courseplay.hud:setCombineAIDriverContent(vehicle)
 	self:debug(vehicle,"setCombineAIDriverContent")
 	--page 0 
 	self:enablePageButton(vehicle, 0)
-	self:addRowButton(vehicle,'toggleWantsCourseplayer', 0, 1, 1 )
+	self:addRowButton(vehicle,'Setting:combineWantsCourseplayer:toggle', 0, 1, 1 )
 	self:addRowButton(vehicle,'startStopCourseplayer', 0, 2, 1 )
 	self:addRowButton(vehicle,'sendCourseplayerHome', 0, 3, 1 )
 	if vehicle.cp.isChopper then	
 		self:addRowButton(vehicle,'switchCourseplayerSide', 0, 4, 1 )
-		self:addRowButton(vehicle,'toggleTurnStage', 0, 5, 1 )
+		self:addRowButton(vehicle,'Setting:turnStage:toggle', 0, 5, 1 )
 	else
-		self:addRowButton(vehicle,'toggleDriverPriority', 0, 4, 1 )
-		self:addRowButton(vehicle,'toggleStopWhenUnloading', 0, 5, 1 ):setOnlyCallLocal();
+		self:addRowButton(vehicle,'Setting:driverPriorityUseFillLevel:toggle', 0, 4, 1 )
+		self:addRowButton(vehicle,'Setting:stopForUnload:toggle', 0, 5, 1 ):setOnlyCallLocal();
 		self:addRowButton(vehicle,'changeHeadlandReverseManeuverType', 0, 6, 1 )
 	end
 	self:setReloadPageOrder(vehicle, -1, true)
@@ -2425,8 +2441,8 @@ function courseplay.hud:setCombineUnloadAIDriverContent(vehicle)
 	self:addSettingsRowWithArrows(vehicle,'changeTipperOffset', 8, 2, 1 )
 	self:addSettingsRowWithArrows(vehicle,'changeDriveOnAtFillLevel', 8, 3, 1 )
 	self:addSettingsRowWithArrows(vehicle,'changeFollowAtFillLevel', 8, 4, 1 )
-	self:addRowButton(vehicle,'toggleRealisticDriving', 8, 5, 1 )
-	self:addRowButton(vehicle,'toggleTurnOnField', 8, 6, 1 )
+	self:addRowButton(vehicle,'Setting:useRealisticDriving:toggle', 8, 5, 1 )
+	self:addRowButton(vehicle,'Setting:turnOnField:toggle', 8, 6, 1 )
 	
 	self:setReloadPageOrder(vehicle, -1, true)
 end
@@ -2463,7 +2479,7 @@ end
 
 function courseplay.hud:setBaleLoaderAIDriverContent(vehicle)
 	self:debug(vehicle,"setBaleLoaderAIDriverContent")
-	self:addRowButton(vehicle,'toggleAutomaticUnloadingOnField', 3, 6, 1 )
+	self:addRowButton(vehicle,'Setting:automaticUnloadingOnField:toggle', 3, 6, 1 )
 	
 	self:setReloadPageOrder(vehicle, -1, true)
 end

--- a/settings.lua
+++ b/settings.lua
@@ -125,26 +125,6 @@ function courseplay:setConvoyMaxDistance(vehicle, changeBy)
 	vehicle.cp.convoy.maxDistance = MathUtil.clamp(vehicle.cp.convoy.maxDistance + changeBy*10, 40, 3000);
 end
 
-function courseplay:toggleFuelSaveOption(self)
-	self.cp.settings.saveFuelOption:toggle()
-end
-
-function courseplay:toggleRidgeMarkersAutomatic(self)
-	self.cp.ridgeMarkersAutomatic = not self.cp.ridgeMarkersAutomatic
-end
-
-function courseplay:toggleAutomaticUnloadingOnField(self)
-	self.cp.settings.automaticUnloadingOnField:toggle()
-end
-
-function courseplay:toggleAutoRefuel(self)
-	self.cp.settings.allwaysSearchFuel:toggle()
-end
-
-function courseplay:toggleAutomaticCoverHandling (self)
-	self.cp.settings.automaticCoverHandling:toggle()
-end
-
 function courseplay:toggleMode10automaticSpeed(self)
 	if self.cp.mode10.leveling then
 		self.cp.mode10.automaticSpeed = not self.cp.mode10.automaticSpeed
@@ -165,10 +145,6 @@ end
 function courseplay:toggleMode10SearchMode(self)
 	self.cp.mode10.searchCourseplayersOnly = not self.cp.mode10.searchCourseplayersOnly
 end
-
-function courseplay:toggleWantsCourseplayer(combine)
-	combine.cp.settings.combineWantsCourseplayer:toggle()
-end;
 
 function courseplay:toggleOppositeTurnMode(vehicle)
 	vehicle.cp.oppositeTurnMode = not vehicle.cp.oppositeTurnMode
@@ -213,10 +189,6 @@ function courseplay:cancelWait(vehicle, cancelStopAtEnd)
 	end;
 end;
 
-function courseplay:setStopAtEnd(vehicle)
-	vehicle.cp.settings.stopAtEnd:toggle()
-end;
-
 function courseplay:setDriveUnloadNow(vehicle, bool)
 	if vehicle then
 		vehicle.cp.settings.driveUnloadNow:set(bool)
@@ -228,9 +200,7 @@ function courseplay:sendCourseplayerHome(combine)
 	courseplay:setDriveUnloadNow(g_combineUnloadManager:getUnloaderByNumber(1, combine), true);
 end
 
-function courseplay:toggleTurnStage(combine)
-	combine.cp.turnStage = self.cp.turnStage== 0 and 1 or 0 ;
-end
+
 
 function courseplay:switchCourseplayerSide(combine)
 	if courseplay:isChopper(combine) then
@@ -479,10 +449,6 @@ function courseplay:toggleShowVisualWaypointsCrossing(vehicle, force, visibility
 		courseplay.signs:setSignsVisibility(vehicle);
 	end;
 end;
-
-function courseplay:toggleTurnOnField(vehicle)
-	vehicle.cp.turnOnField = not vehicle.cp.turnOnField
-end
 	
 function courseplay:changeMode10Radius (vehicle, changeBy)
 	vehicle.cp.mode10.searchRadius = math.max(1,vehicle.cp.mode10.searchRadius + changeBy)
@@ -565,19 +531,6 @@ function courseplay:changeBunkerSpeed(vehicle, changeBy)
 	speed = MathUtil.clamp(speed + changeBy, 3, upperLimit);
 	vehicle.cp.speeds.bunkerSilo = speed;
 end
-
-function courseplay:toggleUseRecordingSpeed(vehicle)
-	vehicle.cp.settings.useRecordingSpeed:toggle()
-end;
-
-function courseplay:changeWarningLightsMode(vehicle, changeBy)
-	local number = MathUtil.clamp(vehicle.cp.settings.warningLightsMode:get() + changeBy, WarningLightsModeSetting.WARNING_LIGHTS_NEVER, WarningLightsModeSetting.WARNING_LIGHTS_BEACON_ALWAYS);
-	vehicle.cp.settings.warningLightsMode:set(number)
-end;
-
-function courseplay:toggleRealisticDriving(vehicle)
-	vehicle.cp.settings.useRealisticDriving:toggle(number)
-end;
 
 function courseplay:toggleAutoDriveMode(vehicle)
 	vehicle.cp.settings.autoDriveMode:next()
@@ -1085,11 +1038,6 @@ function courseplay:changeStartingDirection(vehicle)
 	courseplay:validateCourseGenerationData(vehicle);
 end;
 
-function courseplay:toggleReturnToFirstPoint(vehicle)
-	-- TODO refactor the HUD to enable calling non-courseplay functions (pass in object)
-	vehicle.cp.settings.returnToFirstPoint:toggle()
-end;
-
 function courseplay:changeHeadlandNumLanes(vehicle, changeBy)
 	vehicle.cp.headland.numLanes = MathUtil.clamp(vehicle.cp.headland.numLanes + changeBy,
 		vehicle.cp.headland.getMinNumLanes(), vehicle.cp.headland.getMaxNumLanes());
@@ -1253,10 +1201,6 @@ function courseplay:toggleShovelStopAndGo(vehicle)
 	vehicle.cp.shovelStopAndGo = not vehicle.cp.shovelStopAndGo;
 end;
 
-function courseplay:changeStartAtPoint(vehicle)
-	vehicle.cp.settings.startingPoint:next()
-end;
-
 function courseplay:reloadCoursesFromXML(vehicle)
 	courseplay:debug("reloadCoursesFromXML()", 8);
 	if g_server ~= nil then
@@ -1326,18 +1270,6 @@ function courseplay:changeDebugChannelSection(vehicle, changeBy)
 	--courseplay.buttons:setActiveEnabled(vehicle, 'debug');
 end;
 
-function courseplay:toggleSymmetricLaneChange(vehicle)
-	vehicle.cp.settings.symmetricLaneChange:toggle()
-end;
-
-function courseplay:toggleDriverPriority(combine)
-	combine.cp.settings.driverPriorityUseFillLevel:toggle()
-end;
-
-function courseplay:toggleStopWhenUnloading(combine)
-	combine.cp.settings.stopForUnload:toggle()
-end
-
 function courseplay:goToVehicle(curVehicle, targetVehicle)
 	-- print(string.format("%s: goToVehicle(): targetVehicle=%q", nameNum(curVehicle), nameNum(targetVehicle)));
 	g_client:getServerConnection():sendEvent(VehicleEnterRequestEvent:new(targetVehicle, g_currentMission.missionInfo.playerStyle, g_currentMission.player.ownerFarmId));
@@ -1345,8 +1277,6 @@ function courseplay:goToVehicle(curVehicle, targetVehicle)
 	CpManager.playerOnFootMouseEnabled = false;
 	g_inputBinding:setShowMouseCursor(targetVehicle.cp.mouseCursorActive);
 end;
-
-
 
 --FIELD EDGE PATHS
 function courseplay:createFieldEdgeButtons(vehicle)
@@ -1564,15 +1494,6 @@ function courseplay:changeLastValidTipDistance(vehicle, changeBy)
 	vehicle.cp.lastValidTipDistance = MathUtil.clamp(vehicle.cp.lastValidTipDistance + changeBy, -500, 0);
 end;
 
-function courseplay:changemaxRunNumber(vehicle, changeBy)
- 	local number = MathUtil.clamp(vehicle.cp.settings.runCounterMax:get() + changeBy, 0, 10);
-	vehicle.cp.settings.runCounterMax:set(number)
-end;
-
-function courseplay:resetRunCounter(vehicle)
-	vehicle.cp.driver:resetRunCounter()
-end
-
 function courseplay:toggleSucHud(vehicle)
 	vehicle.cp.suc.active = not vehicle.cp.suc.active;
 	---courseplay.buttons:setActiveEnabled(vehicle, 'suc');
@@ -1698,17 +1619,6 @@ function courseplay:deleteMapHotspot(vehicle)
 	end
 end
 
-function courseplay:toggleIngameMapIconShowText(vehicle)
-	vehicle.cp.settings.showMapHotspot:setNext() 
-	-- for _,vehicle in pairs(g_currentMission.enterables) do
-	for _,vehicle in pairs(CpManager.activeCoursePlayers) do
-		if vehicle.cp.mapHotspot then
-			vehicle.cp.mapHotspot:setText('CP\n' .. courseplay:getMapHotspotText(vehicle))
-			courseplay.hud:setReloadPageOrder(vehicle, 7, true);
-		end;
-	end;
-end;
-
 function courseplay:changeDriveControlMode(vehicle, changeBy)
 	vehicle.cp.driveControl.mode = MathUtil.clamp(vehicle.cp.driveControl.mode + changeBy, vehicle.cp.driveControl.OFF, vehicle.cp.driveControl.AWD_BOTH_DIFF);
 end;
@@ -1786,11 +1696,11 @@ function courseplay:toggleAssignCombineToTractor(vehicle,line)
 	end
 end
 
-function courseplay:shiftCombinesList(vehicle, change_by)
-	if vehicle.cp.driver.shiftCombinesList then 
-		vehicle.cp.driver:shiftCombinesList(change_by)
-	end
-end
+--function courseplay:shiftCombinesList(vehicle, change_by)
+--	if vehicle.cp.driver.shiftCombinesList then 
+--		vehicle.cp.driver:shiftCombinesList(change_by)
+--	end
+--end
 ----------------------------------------------------------------------------------------------------
 
 function courseplay:setCpVar(varName, value, noEventSend)
@@ -2196,7 +2106,67 @@ end
 function SettingList:getNetworkCurrentValue()
 	return self.current
 end
+---WIP
+---Generic LinkedList setting and Interface for LinkedList.lua
+---@class LinkedList : Setting
+LinkedListSetting = CpObject(Setting)
 
+function LinkedListSetting:init(name, label, toolTip, vehicle)
+	Setting.init(self, name, label, toolTip, vehicle)
+	self.List = LinkedList({value=nil,text="Dummy"})
+end
+
+function LinkedListSetting:moveUpByIndex(index)
+	self.List:swapUpX(index)
+end
+
+function LinkedListSetting:moveDownByIndex(index)
+	self.List:swapDownX(index)
+end
+
+function LinkedListSetting:addLast(data)
+	self.List:addLast(data)
+end
+
+function LinkedListSetting:deleteByIndex(index)
+	self.List:removeX(index)
+end
+
+function LinkedListSetting:getText(index)
+	data = self:getDataByIndex(index)
+	if data and data.text then 
+		return data.text
+	else
+		return ""
+	end
+end
+
+function LinkedListSetting:getDataByIndex(index)
+	local element = self.List:getElementByIndex(index)
+	if element and element.data then 
+		return element.data
+	end
+end
+
+function LinkedListSetting:getSize()
+	return self.List:getSize()
+end
+
+function LinkedListSetting:getData()
+	return self.List:getData()
+end
+
+function LinkedListSetting:getDataXtoY(x,y)	
+	return self.List:getDataXtoY(x,y)
+end
+
+function LinkedListSetting:onWriteStream(stream)
+	--override code
+end
+
+function LinkedListSetting:onReadStream(stream)
+	--override code
+end
 --- Generic boolean setting
 ---@class BooleanSetting : SettingList
 BooleanSetting = CpObject(SettingList)
@@ -2742,26 +2712,11 @@ function DriverPriorityUseFillLevelSetting:init(vehicle)
 	self:set(false)
 end
 
----@class RunCounterMaxSetting : SettingList
-RunCounterMaxSetting = CpObject(SettingList)
-RunCounterMaxSetting.RUN_COUNTER_OFF = 0
-function RunCounterMaxSetting:init(vehicle)
-	SettingList.init(self, 'runCounterMax', 'COURSEPLAY_NUMBER_OF_RUNS', 'COURSEPLAY_NUMBER_OF_RUNS', vehicle,
-			{ RunCounterMaxSetting.RUN_COUNTER_OFF,1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-			{ 'COURSEPLAY_DEACTIVATED','1', '2', '3', '4', '5', '6', '7', '8', '9', '10'}
-		)
-	self:set(0)
-end
-
-function RunCounterMaxSetting:getIsRunCounterActive()
-	return not self:is(self.RUN_COUNTER_OFF)
-end
-
 ---@class UseRecordingSpeedSetting : BooleanSetting
 UseRecordingSpeedSetting = CpObject(BooleanSetting)
 function UseRecordingSpeedSetting:init(vehicle)
 	BooleanSetting.init(self, 'useRecordingSpeed', 'COURSEPLAY_MAX_SPEED_MODE', 'COURSEPLAY_MAX_SPEED_MODE', vehicle, {'COURSEPLAY_MAX_SPEED_MODE_MAX','COURSEPLAY_MAX_SPEED_MODE_RECORDING'})
-	self:set(false)
+	self:set(true)
 end
 
 ---@class WarningLightsModeSetting : SettingList
@@ -2811,6 +2766,16 @@ function ShowMapHotspotSetting:init(vehicle)
 	self:set(2)
 end
 
+function ShowMapHotspotSetting:onChange()
+	--TODO get the other components in here ??
+	for _,vehicle in pairs(CpManager.activeCoursePlayers) do
+		if vehicle.cp.mapHotspot then
+			vehicle.cp.mapHotspot:setText('CP\n' .. courseplay:getMapHotspotText(vehicle))
+			courseplay.hud:setReloadPageOrder(vehicle, 7, true)
+		end
+	end
+end
+
 ---@class SaveFuelOptionSetting : BooleanSetting
 SaveFuelOptionSetting = CpObject(BooleanSetting)
 function SaveFuelOptionSetting:init(vehicle)
@@ -2844,6 +2809,220 @@ function CombineWantsCourseplayerSetting:init(vehicle)
 	BooleanSetting.init(self, 'combineWantsCourseplayer', 'COURSEPLAY_DRIVER', 'COURSEPLAY_DRIVER', vehicle, {'COURSEPLAY_REQUEST_UNLOADING_DRIVER','COURSEPLAY_UNLOADING_DRIVER_REQUESTED'})
 	self:set(false)
 end
+
+---@class SiloSelectedFillTypeSetting : LinkedListSetting
+SiloSelectedFillTypeSetting = CpObject(LinkedListSetting)
+function SiloSelectedFillTypeSetting:init(vehicle)
+	LinkedListSetting.init(self, 'siloSelectedFillType', 'COURSEPLAY_FARM_SILO_FILL_TYPE', 'COURSEPLAY_FARM_SILO_FILL_TYPE', vehicle)
+	self.MAX_RUNS = 20
+	self.MAX_FILLTYPES = 5
+	self.xmlKey = 'siloSelectedFillType'
+	self.xmlAttributeSize = '#size'
+	self.xmlAttributeRunCounter = '#runCounter'
+	self.xmlAttributeFillType = '#fillType'
+end
+
+function SiloSelectedFillTypeSetting:addFilltype()
+	if self:isFull() then 
+		return
+	end
+	local supportedFillTypes = {}
+	self:getSupportedFillTypes(self.vehicle,supportedFillTypes)
+	self:checkSelectedFillTypes(supportedFillTypes)
+	if supportedFillTypes then
+		g_gui:showSiloDialog({title="Filltype Selection", fillLevels=supportedFillTypes, capacity=100, callback=self.onFillTypeSelection, target=self, hasInfiniteCapacity = true})
+	end
+end
+
+function SiloSelectedFillTypeSetting:isFull()
+	if self:getSize() >= self.MAX_FILLTYPES then 
+		return true
+	end
+	return false
+end
+
+function SiloSelectedFillTypeSetting:onFillTypeSelection(selectedFillType)
+	if selectedFillType and selectedFillType ~= FillType.UNKNOWN then 
+		self:addLast({fillType = selectedFillType, text = g_fillTypeManager:getFillTypeByIndex(selectedFillType).title, runCounter = self.MAX_RUNS})
+	end
+end  
+
+function SiloSelectedFillTypeSetting:checkSelectedFillTypes(supportedFillTypes)
+	selectedFillTypes = self:getFillTypes()
+	for index,data in ipairs(selectedFillTypes) do 
+		if supportedFillTypes[data.fillType] then
+			supportedFillTypes[data.fillType]=0
+		else
+			--TODO maybe use to clean up old fillType after disconnect trailer or change mode ??
+			--self:deleteByIndex(index) 
+		end
+	end
+end 
+
+function SiloSelectedFillTypeSetting:getSupportedFillTypes(object,supportedFillTypes)  
+	if object and object.spec_fillUnit and object:getFillUnits() then
+		if supportedFillTypes ~= nil then 
+			for fillUnitIndex, fillUnit in pairs(object:getFillUnits()) do
+				for fillType,bool in pairs(object:getFillUnitSupportedFillTypes(fillUnitIndex)) do 
+					if bool then 
+						if supportedFillTypes[fillType] == nil then
+							supportedFillTypes[fillType]=100
+						end
+					end
+				end		
+			end
+		end
+	end
+	-- get all attached implements recursively
+	for _,impl in pairs(object:getAttachedImplements()) do
+		self:getSupportedFillTypes(impl.object,supportedFillTypes)
+	end
+end
+
+--TODO: fix this one
+function SiloSelectedFillTypeSetting:isActive()  
+	local data = self:getData()
+	local runCounterCheck = false
+	for _,data in pairs(data) do 
+		if data.runCounter > 0 then 
+			runCounterCheck=true
+		end
+	end
+	return runCounterCheck
+end
+
+function SiloSelectedFillTypeSetting:hasFillTypes()  
+	if #self:getFillTypes()>0 then 
+		return true
+	end
+	return false
+end
+
+function SiloSelectedFillTypeSetting:getFillTypes()  
+	local totalData = self:getData()
+	local fillTypes = {}
+	local i=1
+	for _,data in ipairs(totalData) do 
+		local fillTypeData = {}
+		fillTypeData.fillType = data.fillType
+		fillTypeData.runCounter = data.runCounter
+		fillTypes[i]=fillTypeData
+		i=i+1
+	end
+	return fillTypes
+end
+
+function SiloSelectedFillTypeSetting:getRunCounterText(index)
+	local data = self:getDataByIndex(index)
+	if data and data.runCounter then 
+		local strg = data.runCounter.."/"..self.MAX_RUNS
+		return strg
+	else
+		return ""
+	end
+end
+
+function SiloSelectedFillTypeSetting:incrementRunCounter(index)
+	local data = self:getDataByIndex(index)
+	if data and data.runCounter then 
+		if not (data.runCounter >= self.MAX_RUNS) then 
+			data.runCounter = data.runCounter+1
+		end
+	end
+end
+
+function SiloSelectedFillTypeSetting:decrementRunCounterByFillType(fillTypes)
+	local fillTypeData = self:getFillTypes()
+	for index,data in ipairs(fillTypeData) do 
+		for _,fillType in ipairs(fillTypes) do 
+			if data.fillType == fillType then
+				local _data = self:getDataByIndex(index)
+				_data.runCounter = _data.runCounter-1
+				break
+			else
+		
+			end
+		end
+	end
+end
+
+function SiloSelectedFillTypeSetting:decrementRunCounter(index)
+	local data = self:getDataByIndex(index)
+	if data and data.runCounter then 
+		if not (data.runCounter <= 0) then 
+			data.runCounter = data.runCounter-1
+		end
+	end
+end
+
+function SiloSelectedFillTypeSetting:getKey(parentKey)
+	return parentKey .. '.' .. self.xmlKey
+end
+
+function SiloSelectedFillTypeSetting:loadFromXml(xml, parentKey)
+	local size = getXMLInt(xml, self:getKey(parentKey)..self.xmlAttributeSize)
+	if size and size>0 then
+		for key=1,size do 
+			local elementKey = string.format("%s.element(%d)", self:getKey(parentKey), key-1)
+			local selectedFillType = getXMLInt(xml, elementKey..self.xmlAttributeFillType)
+			local counter = getXMLInt(xml, elementKey..self.xmlAttributeRunCounter)
+			if selectedFillType and counter then 
+				self:addLast({fillType = selectedFillType, text = g_fillTypeManager:getFillTypeByIndex(selectedFillType).title, runCounter = counter})
+			end
+		end
+	end
+end
+
+function SiloSelectedFillTypeSetting:saveToXml(xml, parentKey)
+	local size = self:getSize()
+	setXMLInt(xml, self:getKey(parentKey)..self.xmlAttributeSize, Utils.getNoNil(size,0))
+	if size > 0 then 
+		for key,data in ipairs(self.List:getData()) do
+			local elementKey = string.format("%s.element(%d)", self:getKey(parentKey), key-1)
+			setXMLInt(xml, elementKey..self.xmlAttributeFillType, Utils.getNoNil(data.fillType,0))
+			setXMLInt(xml, elementKey..self.xmlAttributeRunCounter, Utils.getNoNil(data.runCounter,0))
+		end
+	end
+end
+
+function SiloSelectedFillTypeSetting:onWriteStream(stream)
+	local size = self:getSize() or 0
+	streamDebugWriteInt32(stream, size)
+	if size > 0 then 
+		for key,data in ipairs(self.List:getData()) do
+			streamDebugWriteInt32(stream, data.fillType)
+			streamDebugWriteInt32(stream, data.runCounter)
+		end
+	end
+end
+
+function SiloSelectedFillTypeSetting:onReadStream(stream)
+	local size = streamDebugReadInt32(stream)
+	if size and size>0 then
+		for key=1,size do 
+			local selectedFillType = streamDebugReadInt32(stream)
+			local counter = streamDebugReadInt32(stream)
+			if selectedFillType and counter then 
+				self:addLast({fillType = selectedFillType, text = g_fillTypeManager:getFillTypeByIndex(selectedFillType).title, runCounter = counter})
+			end
+		end
+	end
+end
+
+---@class TurnOnFieldSetting : BooleanSetting
+TurnOnFieldSetting = CpObject(BooleanSetting)
+function TurnOnFieldSetting:init(vehicle)
+	BooleanSetting.init(self, 'turnOnField','COURSEPLAY_TURN_ON_FIELD', 'COURSEPLAY_TURN_ON_FIELD', vehicle) 
+	self:set(true)
+end
+
+---@class TurnStageSetting : BooleanSetting
+TurnStageSetting = CpObject(BooleanSetting)
+function TurnStageSetting:init(vehicle)
+	BooleanSetting.init(self, 'turnStage','COURSEPLAY_TURN_MANEUVER', 'COURSEPLAY_TURN_MANEUVER', vehicle, {'COURSEPLAY_START','COURSEPLAY_FINISH'}) 
+	self:set(false)
+end
+
 
 --- Container for settings
 --- @class SettingsContainer

--- a/start_stop.lua
+++ b/start_stop.lua
@@ -500,7 +500,7 @@ function courseplay:stop(self)
 	self.cp.turnTimeRecorded = nil;	
 	self.cp.hasUnloadingRefillingCourse = false;
 	self.cp.hasTransferCourse = false
-	courseplay:setStopAtEnd(self, false);
+	self.cp.settings.stopAtEnd:set(false)
 	self.cp.stopAtEndMode1 = false;
 	self.cp.isTipping = false;
 	self.cp.isUnloaded = false;

--- a/toolManager.lua
+++ b/toolManager.lua
@@ -854,6 +854,45 @@ function courseplay:load_tippers(vehicle, allowedToDrive)
 	if vehicle.cp.tipperLoadMode == 1 and currentTrailer.cp.currentSiloTrigger ~= nil and not driveOn then
         local acceptedFillType = false;
 		local siloTrigger = currentTrailer.cp.currentSiloTrigger;
+		local fillTypeData = vehicle.cp.settings.siloSelectedFillType:getFillTypes()
+		if not siloTrigger.isLoading and (vehicle.cp.siloSelectedFillType==nil or vehicle.cp.siloSelectedFillType==FillType.UNKNOWN) then
+			vehicle.cp.siloSelectedFillType = FillType.UNKNOWN
+			if fillTypeData then 
+				for _,data in ipairs(fillTypeData) do 
+					if data.runCounter >0 then 
+						if courseplay:fillTypesMatch(vehicle, siloTrigger, currentTrailer) then	
+							local breakLoop = false
+							local fillLevels, capacity
+							if siloTrigger.source and  siloTrigger.source.getAllFillLevels then 
+								fillLevels, capacity = siloTrigger.source:getAllFillLevels(g_currentMission:getFarmId())
+							elseif siloTrigger.source and siloTrigger.source.getAllProvidedFillLevels then
+								fillLevels, capacity = siloTrigger.source:getAllProvidedFillLevels(g_currentMission:getFarmId(), siloTrigger.managerId)
+							else
+								courseplay:debug('fillLevels not found !!', 2);
+								breakLoop=true
+								break
+							end						
+							for fillTypeIndex, fillLevel in pairs(fillLevels) do
+								if fillTypeIndex == data.fillType then 
+									if fillLevel > 0 then 
+										vehicle.cp.siloSelectedFillType = data.fillType
+										breakLoop=true
+										break
+									else
+							
+									end
+								end
+							end
+							if breakLoop then 
+								break
+							end
+						else
+						
+						end
+					end		
+				end
+			end
+		end
 		if courseplay:fillTypesMatch(vehicle, siloTrigger, currentTrailer) then	
 			local siloIsEmpty = false --siloTrigger:getFillLevel(vehicle.cp.siloSelectedFillType) <= 1;
 			if not siloTrigger.isLoading and not siloIsEmpty and (unloadDistance < vehicle.cp.trailerFillDistance or backUpDistance < 1 ) then
@@ -2212,6 +2251,3 @@ function courseplay:openCloseCover(vehicle, showCover, fillTrigger)
 		end;
 	end; --END for i,tipperWithCover in vehicle.cp.tippersWithCovers
 end;
-
-
-

--- a/turn.lua
+++ b/turn.lua
@@ -114,7 +114,7 @@ function courseplay:turn(vehicle, dt, turnContext)
 	----------------------------------------------------------
 	-- TURN STAGES 1 - Create Turn maneuver (Creating waypoints to follow)
 	----------------------------------------------------------
-	if vehicle.cp.turnStage == 1 then
+	if vehicle.cp.settings.turnStage:is(true) then
 		--- Cleanup in case we already have old info
 		courseplay:clearTurnTargets(vehicle); -- Make sure we have cleaned it from any previus usage.
 
@@ -139,7 +139,7 @@ function courseplay:turn(vehicle, dt, turnContext)
 		turnInfo.headlandHeight 				= turnContext.turnStartWp.headlandHeightForTurn and
 				turnContext.turnStartWp.headlandHeightForTurn or vehicle.cp.headlandHeight;
 		turnInfo.numLanes ,turnInfo.onLaneNum 	= courseplay:getLaneInfo(vehicle);
-		turnInfo.turnOnField 					= vehicle.cp.turnOnField;
+		turnInfo.turnOnField 					= vehicle.cp.settings.turnOnField:is(true);
 		turnInfo.reverseOffset 					= 0;
 		turnInfo.extraAlignLength				= 6;
 		turnInfo.haveWheeledImplement 			= reversingWorkTool ~= nil;
@@ -1531,7 +1531,7 @@ function courseplay:addTurnTarget(vehicle, posX, posZ, turnEnd, turnReverse, rev
 end
 
 function courseplay:clearTurnTargets(vehicle)
-	vehicle.cp.turnStage = 0;
+	vehicle.cp.settings.turnStage:set(false)
 	vehicle.cp.turnTargets = {};
 	vehicle.cp.curTurnIndex = 1;
 	vehicle.cp.haveCheckedMarkersThisTurn = false;


### PR DESCRIPTION
added direct button function calls for settings

mode 1: added runCounter for FillTypes

-added Linked List for FillTypes
-allows filling of more then one FillType in order
-specific Runcounters for each FillTypes

some cleanup and 2 settings move to SettingsContainer

-TurnOnFieldSetting
-TurnStageSetting
-almost every setting in hud gets directly called now like cp.xy:toggle() by the hud and not a courseplay:toggleXY() one