### PR TITLE
Straw Harvest Premos Support

### DIFF
--- a/AIDriver.lua
+++ b/AIDriver.lua
@@ -423,7 +423,7 @@ function AIDriver:driveCourse(dt)
 		self:setSpeed(self:getRecordedSpeed())
 	end
 	local isInTrigger, isAugerWagonTrigger = self.triggerHandler:isInTrigger()
-	if self:getIsInFilltrigger() or isInTrigger then
+	if self:getIsInFilltrigger() then
 		self:setSpeed(self.vehicle.cp.speeds.approach)
 		if isAugerWagonTrigger then 
 			self:setSpeed(self.APPROACH_AUGER_TRIGGER_SPEED)

--- a/AIDriver.lua
+++ b/AIDriver.lua
@@ -423,7 +423,7 @@ function AIDriver:driveCourse(dt)
 		self:setSpeed(self:getRecordedSpeed())
 	end
 	local isInTrigger, isAugerWagonTrigger = self.triggerHandler:isInTrigger()
-	if self:getIsInFilltrigger() then
+	if self:getIsInFilltrigger() or isInTrigger then
 		self:setSpeed(self.vehicle.cp.speeds.approach)
 		if isAugerWagonTrigger then 
 			self:setSpeed(self.APPROACH_AUGER_TRIGGER_SPEED)

--- a/CombineAIDriver.lua
+++ b/CombineAIDriver.lua
@@ -86,7 +86,6 @@ function CombineAIDriver:init(vehicle)
 		local implementWithPipe = AIDriverUtil.getAIImplementWithSpecialization(self.vehicle, Pipe)
 		if implementWithPipe then
 			self.pipe = implementWithPipe.spec_pipe
-            self.combine.spec_pipe = self.pipe
 			self.objectWithPipe = implementWithPipe
 		else
 			self:info('Could not find implement with pipe')
@@ -1012,7 +1011,19 @@ function CombineAIDriver:handlePipe()
 end
 
 function CombineAIDriver:handleCombinePipe()
-	if self:isFillableTrailerUnderPipe() or self:isAutoDriveWaitingForPipe() or (self:isWaitingForUnload() and self.vehicle.cp.settings.pipeAlwaysUnfold:is(true)) then
+    
+    local activeUnloader = nil
+    local unloader
+    for _, unloader in ipairs(self.unloaders) do
+        if unloader.combineToUnload == self then
+            if unloader.onFieldState == unloader.states.DRIVE_TO_MOVING_COMBINE then
+                activeUnloader = unloader
+            break
+            end
+        end
+    end
+
+	if self:isFillableTrailerUnderPipe() or self:isAutoDriveWaitingForPipe() or (self:isWaitingForUnload() and self.vehicle.cp.settings.pipeAlwaysUnfold:is(true)) or activeUnloader ~= nil then
 		self:openPipe()
 	else
 		--wait until the objects under the pipe are gone

--- a/CombineAIDriver.lua
+++ b/CombineAIDriver.lua
@@ -65,8 +65,15 @@ function CombineAIDriver:init(vehicle)
 		self.combine = self.vehicle.spec_combine
 	else
 		local combineImplement = AIDriverUtil.getAIImplementWithSpecialization(self.vehicle, Combine)
+        local peletizerImplement = AIDriverUtil.getAIImplementWithSpecialization(self.vehicle, FS19_addon_strawHarvest.StrawHarvestPelletizer)
 		if combineImplement then
 			self.combine = combineImplement.spec_combine
+        elseif peletizerImplement then
+            self.combine = peletizerImplement
+            self.combine.fillUnitIndex = 1
+            self.combine.spec_aiImplement.rightMarker = self.combine.rootNode
+            self.combine.spec_aiImplement.leftMarker  = self.combine.rootNode
+            self.combine.spec_aiImplement.backMarker  = self.combine.rootNode
 		else
 			self:error('Vehicle is not a combine and could not find implement with spec_combine')
 		end
@@ -79,6 +86,7 @@ function CombineAIDriver:init(vehicle)
 		local implementWithPipe = AIDriverUtil.getAIImplementWithSpecialization(self.vehicle, Pipe)
 		if implementWithPipe then
 			self.pipe = implementWithPipe.spec_pipe
+            self.combine.spec_pipe = self.pipe
 			self.objectWithPipe = implementWithPipe
 		else
 			self:info('Could not find implement with pipe')

--- a/CombineAIDriver.lua
+++ b/CombineAIDriver.lua
@@ -1012,18 +1012,7 @@ end
 
 function CombineAIDriver:handleCombinePipe()
     
-    local activeUnloader = nil
-    local unloader
-    for _, unloader in ipairs(self.unloaders) do
-        if unloader.combineToUnload == self then
-            if unloader.onFieldState == unloader.states.DRIVE_TO_MOVING_COMBINE then
-                activeUnloader = unloader
-            break
-            end
-        end
-    end
-
-	if self:isFillableTrailerUnderPipe() or self:isAutoDriveWaitingForPipe() or (self:isWaitingForUnload() and self.vehicle.cp.settings.pipeAlwaysUnfold:is(true)) or activeUnloader ~= nil then
+  if self:isFillableTrailerUnderPipe() or self:isAutoDriveWaitingForPipe() or (self:isWaitingForUnload() and self.vehicle.cp.settings.pipeAlwaysUnfold:is(true)) then
 		self:openPipe()
 	else
 		--wait until the objects under the pipe are gone

--- a/CombineUnloadManager.lua
+++ b/CombineUnloadManager.lua
@@ -79,7 +79,7 @@ function CombineUnloadManager:addCombineToList(vehicle, driver)
 		driver = driver,
 		combineObject = combineObject,
 		isChopper = courseplay:isChopper(combineObject),
-		isCombine = courseplay:isCombine(combineObject) and not courseplay:isChopper(combineObject),
+		isCombine = (courseplay:isCombine(combineObject) or combineObject.isPremos) and not courseplay:isChopper(combineObject),
 		isOnFieldNumber = 0;
 		fillLevel = 0;
 		fillLevelPct = 0;

--- a/UnloadableFieldworkAIDriver.lua
+++ b/UnloadableFieldworkAIDriver.lua
@@ -61,6 +61,8 @@ function UnloadableFieldworkAIDriver.create(vehicle)
 	elseif SpecializationUtil.hasSpecialization(Plow, vehicle.specializations) or
 		AIDriverUtil.hasAIImplementWithSpecialization(vehicle, Plow) then
 		return PlowAIDriver(vehicle)
+    elseif AIDriverUtil.hasAIImplementWithSpecialization(vehicle, FS19_addon_strawHarvest.StrawHarvestPelletizer) then
+        return CombineAIDriver(vehicle)
 	else
 		return UnloadableFieldworkAIDriver(vehicle)
 	end


### PR DESCRIPTION
- Straw Harvest Premos Support
  - Treat Premos like a Combine spec (eg sugarbeet trailed harvester Rootster)
  - Creative Mesh (author) treats it like a baler, markers where simulated
- AIDriver rogue check fix
  - `isInTrigger `check makes no sense, no prior assignment
  - Fixes driver using the approach for no apparent reason