### PR TITLE
Update OverloaderAIDriver.lua

### DIFF
--- a/OverloaderAIDriver.lua
+++ b/OverloaderAIDriver.lua
@@ -119,7 +119,7 @@ end
 function OverloaderAIDriver:isTrailerEmpty()
     if self.trailer and self.trailer.getFillUnits then
         for _, fillUnit in pairs(self.trailer:getFillUnits()) do
-            if fillUnit.fillLevel > 0 then
+            if fillUnit.fillLevel > 0.1 then
                 return false
             end
         end


### PR DESCRIPTION
Twick to avoid Mode 3 overloaders to get stuck when unloading as they can't get fully empty
Same thing was done for Shovel mode and Mode6 unloading course a while back