### PR TITLE
Better up/down -> headland transition for #6067

### DIFF
--- a/AITurn.lua
+++ b/AITurn.lua
@@ -651,3 +651,24 @@ function CombinePocketHeadlandTurn:turn(dt)
 		self.implementsLowered = true
 	end
 end
+
+--- A turn type which isn't really a turn, we only use this to finish a row (drive straight until the implement
+--- reaches the end of the row, don't drive towards the next waypoint until then)
+--- This is to make sure the last row before transitioning to the headland is properly finished, otherwise
+--- we'd start driving towards the next headland waypoint, turning towards it before the implement reaching the
+--- end of the row and leaving unworked patches.
+---@class FinishRowOnly : AITurn
+FinishRowOnly = CpObject(AITurn)
+
+function FinishRowOnly:init(vehicle, driver, turnContext)
+	AITurn.init(self, vehicle, driver, turnContext, 'FinishRowOnly')
+end
+
+function FinishRowOnly:finishRow()
+	-- keep driving straight until we need to raise our implements
+	if self.driver:shouldRaiseImplements(self:getRaiseImplementNode()) then
+		self:debug('Row finished, returning to fieldwork.')
+		self.driver:resumeFieldworkAfterTurn(self.turnContext.turnEndWpIx)
+	end
+	return false
+end

--- a/FieldworkAIDriver.lua
+++ b/FieldworkAIDriver.lua
@@ -685,6 +685,9 @@ function FieldworkAIDriver:onWaypointChange(ix)
 				self:debug('adding offset (%.1f front marker) to make sure we do not miss anything when the course ends', self.frontMarkerDistance)
 				self.aiDriverOffsetZ = -self.frontMarkerDistance
 			end
+		elseif not self.course:isOnHeadland(ix) and self.course:isOnHeadland(ix + 1) then
+			self:debug('last row waypoint before switching to the headland')
+			self:finishRow(ix)
 		end
 		if self.fieldworkState ~= self.states.TURNING and self.course:isTurnStartAtIx(ix) then
 			self:startTurn(ix)
@@ -698,7 +701,7 @@ function FieldworkAIDriver:onWaypointChange(ix)
 end
 
 function FieldworkAIDriver:onTowedImplementPassedWaypoint(ix)
-	self:debug('Implement passsed waypoint %d', ix)
+	self:debug('Implement passed waypoint %d', ix)
 end
 
 --- Should we return to the first point of the course after we are done?
@@ -1103,6 +1106,14 @@ end
 
 function FieldworkAIDriver:getTurnEndForwardOffset()
 	return 0
+end
+
+function FieldworkAIDriver:finishRow(ix)
+	self:setMarkers()
+	self.turnContext = RowFinishingContext(self.course, ix, self.aiDriverData, self.vehicle.cp.workWidth,
+			self.frontMarkerDistance, self:getTurnEndSideOffset(), self:getTurnEndForwardOffset())
+	self.aiTurn = FinishRowOnly(self.vehicle, self, self.turnContext)
+	self.fieldworkState = self.states.TURNING
 end
 
 function FieldworkAIDriver:startTurn(ix)

--- a/turn.lua
+++ b/turn.lua
@@ -2304,5 +2304,16 @@ function TurnContext:drawDebug()
 	end
 end
 
+--- A special turn context for the RowFinishOnly turn (up/down -> headland transition).
+---@class RowFinishingContext : TurnContext
+RowFinishingContext = CpObject(TurnContext)
+
+--- Force the 180 turn behavior so the row finishing straight course is created properly. Without this
+--- it would calculate a transition to the headland as a headland turn as such transitions are always
+--- less then 180 and then the row finishing course would be offset
+function RowFinishingContext:isHeadlandCorner()
+	return false
+end
+
 -- do not delete this line
 -- vim: set noexpandtab:


### PR DESCRIPTION
Finish last up/down row (drive until implement reaches
the end of the row before turning towards the
next (headland) waypoint.