### PR TITLE
Proximity sensor fixes

### DIFF
--- a/AIDriver.lua
+++ b/AIDriver.lua
@@ -1835,8 +1835,8 @@ function AIDriver:setBackMarkerNode(vehicle)
 	if AIDriverUtil.hasImplementsOnTheBack(vehicle) then
 		local lastImplement
 		lastImplement, backMarkerOffset = AIDriverUtil.getLastAttachedImplement(vehicle)
-		referenceNode = lastImplement.rootNode
-		self:debug('Using the last implement\'s root node for the rear proximity sensor, %d m from root node', backMarkerOffset)
+		referenceNode = vehicle.rootNode
+		self:debug('Using the last implement\'s rear distance for the rear proximity sensor, %d m from root node', backMarkerOffset)
 	elseif reverserNode then
 		-- if there is a reverser node, use that, mainly because that most likely will turn with an implement
 		-- or with the back component of an articulated vehicle. Just need to find out the distance correctly
@@ -1866,7 +1866,6 @@ function AIDriver:getBackMarkerNode(vehicle)
 end
 
 -- Put a node on the front of the vehicle for easy distance checks use this instead of the root/direction node
--- TODO: check for implements at front like weights
 function AIDriver:setFrontMarkerNode(vehicle)
 	local firstImplement, frontMarkerOffset = AIDriverUtil.getFirstAttachedImplement(vehicle)
 	self:debug('Using the %s\'s root node for the front proximity sensor, %d m from root node',
@@ -1876,7 +1875,7 @@ function AIDriver:setFrontMarkerNode(vehicle)
 		vehicle.cp.driver.aiDriverData.frontMarkerNode = courseplay.createNode('frontMarkerNode', 0, 0, 0, vehicle.rootNode)
 	else
 		unlink(vehicle.cp.driver.aiDriverData.frontMarkerNode)
-		link(firstImplement.rootNode, vehicle.cp.driver.aiDriverData.frontMarkerNode)
+		link(vehicle.rootNode, vehicle.cp.driver.aiDriverData.frontMarkerNode)
 	end
 	setTranslation(vehicle.cp.driver.aiDriverData.frontMarkerNode, 0, 0, frontMarkerOffset)
 	-- Make sure the front marker node does not point up or down, for example in case of

--- a/ShovelModeAIDriver.lua
+++ b/ShovelModeAIDriver.lua
@@ -128,6 +128,7 @@ function ShovelModeAIDriver:start()
 	self.course = Course(self.vehicle , self.vehicle.Waypoints)
 	self.ppc:setCourse(self.course)
 	self.ppc:initialize()
+	self:disableProximitySpeedControl()
 	self:disableProximitySwerve()
 	AIDriver.continue(self)
 end

--- a/vehicles.lua
+++ b/vehicles.lua
@@ -1649,46 +1649,46 @@ function AIDriverUtil.getAllAttachedImplements(object, implements)
 	return implements
 end
 
----@return table, number frontmost object and the distance between the front of that object and the root node of the object
+---@return table, number frontmost object and the distance between the front of that object and the root node of the vehicle
+--- when > 0 in front of the vehicle
 function AIDriverUtil.getFirstAttachedImplement(vehicle)
-	-- by default, it is the vehicle's front, negative as the vehicle's root node is behind the front implement's root node
-	local minDistance = 0
-	-- lengthOffset > 0 if the root node is towards the back of the vehicle, < 0 if it is towards the front
-	local frontOffset = vehicle.sizeLength / 2 + vehicle.lengthOffset
+	-- by default, it is the vehicle's front
+	local maxDistance = vehicle.sizeLength / 2 + vehicle.lengthOffset
 	local firstImplement = vehicle
 	for _, implement in pairs(AIDriverUtil.getAllAttachedImplements(vehicle)) do
 		if implement.object ~= nil then
-			local _, _, d = localToLocal(vehicle.rootNode, implement.object.rootNode, 0, 0, implement.object.sizeLength / 2 + implement.object.lengthOffset)
+			-- the distance from the vehicle's root node to the front of the implement
+			local _, _, d = localToLocal(implement.object.rootNode, vehicle.rootNode, 0, 0,
+					implement.object.sizeLength / 2 + implement.object.lengthOffset)
 			courseplay.debugVehicle(6, vehicle, '%s front distance %d', implement.object:getName(), d)
-			if d < minDistance then
-				minDistance = d
-				frontOffset = implement.object.sizeLength / 2 + implement.object.lengthOffset
+			if d > maxDistance then
+				maxDistance = d
 				firstImplement = implement.object
 			end
 		end
 	end
-	return firstImplement, frontOffset
+	return firstImplement, maxDistance
 end
 
 ---@return table, number rearmost object and the distance between the back of that object and the root node of the object
 function AIDriverUtil.getLastAttachedImplement(vehicle)
 	-- by default, it is the vehicle's back
-	local maxDistance = 0
+	local minDistance = vehicle.sizeLength / 2 - vehicle.lengthOffset
 	-- lengthOffset > 0 if the root node is towards the back of the vehicle, < 0 if it is towards the front
-	local backOffset = vehicle.sizeLength / 2 - vehicle.lengthOffset
 	local lastImplement = vehicle
 	for _, implement in pairs(AIDriverUtil.getAllAttachedImplements(vehicle)) do
 		if implement.object ~= nil then
-			local _, _, d = localToLocal(vehicle.rootNode, implement.object.rootNode, 0, 0, - implement.object.sizeLength / 2 + implement.object.lengthOffset)
+			-- the distance from the vehicle's root node to the back of the implement
+			local _, _, d = localToLocal(implement.object.rootNode, vehicle.rootNode, 0, 0,
+					- implement.object.sizeLength / 2 + implement.object.lengthOffset)
 			courseplay.debugVehicle(6, vehicle, '%s back distance %d', implement.object:getName(), d)
-			if d > maxDistance then
-				maxDistance = d
-				backOffset = implement.object.sizeLength / 2 - implement.object.lengthOffset
+			if d < minDistance then
+				minDistance = d
 				lastImplement = implement.object
 			end
 		end
 	end
-	return lastImplement, -backOffset
+	return lastImplement, minDistance
 end
 
 


### PR DESCRIPTION
- disabled proximity speed control for mode 9
- proximity pack is now linked to the vehicle, not the
implement so it does not move for example with a shovel.
- proximity sensor adjusts itself forward (or backward when
looking back) until it does not see the own vehicle or its
implements (#6430)