### PR TITLE
MP: do not slow down for player driven unloader #6536

### DIFF
--- a/CombineAIDriver.lua
+++ b/CombineAIDriver.lua
@@ -1603,3 +1603,24 @@ function CombineAIDriver:addForwardProximitySensor()
 	self.forwardLookingProximitySensorPack = WideForwardLookingProximitySensorPack(
 			self.vehicle, self.ppc, self:getFrontMarkerNode(self.vehicle), self.proximitySensorRange, 1, self.vehicle.cp.workWidth)
 end
+
+--- Check the vehicle in the proximity sensor's range. If it is player driven, don't slow them down when hitting this
+--- vehicle.
+--- Note that we don't really know if the player is to unload the combine, this will disable all proximity check for
+--- player driven vehicles.
+function CombineAIDriver:isProximitySlowDownEnabled(vehicle)
+	-- if not on fieldwork, always enable slowing down
+	if self.state ~= self.states.ON_FIELDWORK_COURSE then return true end
+
+	-- CP drives other vehicle, it'll take care of everything, including enable/disable
+	-- the proximity sensor when unloading
+	if vehicle.cp.driver and vehicle.cp.driver.isActive and vehicle.cp.driver:isActive() then return true end
+
+	if vehicle and vehicle:getIsEntered() then
+		self:debugSparse('human player in nearby %s not driven by CP so do not slow down for it', nameNum(vehicle))
+		-- trust the player to avoid collisions
+		return false
+	else
+		return true
+	end
+end

--- a/CombineUnloadAIDriver.lua
+++ b/CombineUnloadAIDriver.lua
@@ -2073,37 +2073,6 @@ function CombineUnloadAIDriver:drawDebugInfo()
 
 end
 
-
---- If the player drives the unloader, check the vicinity  for combines driven by courseplay
---- and tell them to ignore this vehicle so their proximity sensor won't slow them down when hitting this vehicle.
---- Note that we don't really know if the player is to unload the combine, this will disable all proximity check for
---- player driven vehicles.
-function CombineUnloadAIDriver.disableProximitySensorForNonCourseplayDriver(unloader)
-	if not g_server then return end
-	-- CP drives unloader, it'll take care of everything
-	if unloader.cp.driver and unloader.cp.driver.isActive and unloader.cp.driver:isActive() then return end
-	-- TODO: maybe check for AutoDrive? Or better provide and interface to AutoDrive to disable the proximity sensor?
-	-- no player in unloader, so do not ignore this vehicle
-	if not unloader:getIsEntered() then return end
-
-	-- find combines driven by CP around unloader
-	if g_currentMission then
-		for _, vehicle in pairs(g_currentMission.vehicles) do
-			if vehicle.cp.driver and vehicle.cp.driver.is_a and vehicle.cp.driver:is_a(CombineAIDriver) then
-				local d = calcDistanceFrom(unloader.rootNode, vehicle.rootNode)
-				if d < CombineUnloadAIDriver.safeManeuveringDistance then
-					vehicle.cp.driver:ignoreVehicleProximity(unloader, 3000)
-					--TODO: figure out a possible debug channel, if needed
-
-					--if g_updateLoopIndex % 500 == 0 then
-						--courseplay.infoVehicle(vehicle, 'Proximity sensor deactivated for player driven %s', nameNum(unloader))
-					--end
-				end
-			end
-		end
-	end
-end
-
 function CombineUnloadAIDriver:renderText(x, y, ...)
 
 	if not courseplay.debugChannels[self.debugChannel] then return end

--- a/base.lua
+++ b/base.lua
@@ -773,8 +773,6 @@ function courseplay:onUpdate(dt)
 		courseplay:record(self);
 	end;
 
-	CombineUnloadAIDriver.disableProximitySensorForNonCourseplayDriver(self)
-
 	-- we are in drive mode and single player /MP server
 	if self.cp.isDriving and g_server ~= nil then
 		for refIdx,_ in pairs(CpManager.globalInfoText.msgReference) do


### PR DESCRIPTION
Now the combine checks if a nearby vehicle is driven by the player
and won't slow down if this vehicle is in the proximity sensor's range.