### PR TITLE
Fix #6650

### DIFF
--- a/FieldworkAIDriver.lua
+++ b/FieldworkAIDriver.lua
@@ -448,7 +448,7 @@ function FieldworkAIDriver:stopAndChangeToUnload()
 		self:changeToUnloadOrRefill()
 		self:startCourseWithPathfinding(self.unloadRefillCourse, 1)
 	else
-		if self.vehicle.cp.settings.autoDriveMode:useForUnloadOrRefill() then
+		if self.vehicle.spec_autodrive and self.vehicle.cp.settings.autoDriveMode:useForUnloadOrRefill() then
 			-- Switch to AutoDrive when enabled 
 			self:rememberWaypointToContinueFieldwork()
 			self:stopWork()
@@ -471,7 +471,7 @@ function FieldworkAIDriver:isFuelLevelOk()
 end
 
 function FieldworkAIDriver:stopAndRefuel()
-	if self.vehicle.cp.settings.autoDriveMode:useForUnloadOrRefill() then
+	if self.vehicle.spec_autodrive and self.vehicle.cp.settings.autoDriveMode:useForUnloadOrRefill() and self.vehicle.spec_autodrive.getSetting("autoRefuel", self.vehicle) then
 		-- Switch to AutoDrive when enabled 
 		self:rememberWaypointToContinueFieldwork()
 		self:stopWork()

--- a/hud.lua
+++ b/hud.lua
@@ -661,7 +661,7 @@ function courseplay.hud:updatePageContent(vehicle, page)
 					end				
 				elseif entry.functionToCall == 'autoDriveMode:changeByX' then
 					--autoDriveModeSetting
-					if vehicle.cp.canDrive then
+					if vehicle.cp.canDrive and vehicle.spec_autodrive then
 						self:enableButtonWithFunction(vehicle,page, 'changeByX',vehicle.cp.settings.autoDriveMode)
 						vehicle.cp.hud.content.pages[page][line][1].text = vehicle.cp.settings.autoDriveMode:getLabel()
 						vehicle.cp.hud.content.pages[page][line][2].text = vehicle.cp.settings.autoDriveMode:getText() 


### PR DESCRIPTION
#Only show AutoDrive settings if the mod is installed.
Also take into account AD seting for auto refill: https://github.com/Stephan-S/FS19_AutoDrive/issues/1742