### PR TITLE
6.03.00036 Mode 2 and Mode 5 (reversing) fix

### DIFF
--- a/ValidModeSetupHandler.lua
+++ b/ValidModeSetupHandler.lua
@@ -84,10 +84,10 @@ end
 ---checks if the "mode" is allowed and not disallowed for the vehicle
 ---@param int : cpMode to check
 ---@param vehicle : object, implement,vehicle
----@return boolean : isAllowedOkay, boolean : isDisallowedOkay
+---@return boolean, boolean : true = setup allows this mode, true = setup does not disable this mode
 function ValidModeSetupHandler:isModeValid(mode,object)
 	local validData = self.modeSetup[mode]
-	local isAllowedOkay = false
+	local isAllowedOkay = true
 	local isDisallowedOkay = true
 	if validData then 
 		if validData.allowedSetups then 

--- a/config/ValidModeSetup.xml
+++ b/config/ValidModeSetup.xml
@@ -9,6 +9,7 @@
 	A mode is disabled if one of the specializations under disallowedSetups was found, for either the vehicle or the implement, ..
 	
 	AllowedSetups:
+		- if empty, or the setup is empty, this mode is enabled
 		- each Setup represents an AND Gate (the vehicle must have all of the specializations listed in the Setup group)
 		- multiple Setups represent an OR GATE
 		- as a combination this work like a "Disjunctive normal form"
@@ -67,7 +68,7 @@
 				<Specialization name="spec_trailer"/>
 			</Setup>
 			<Setup>
-			<!-- as an example spezial tools can be enabled by the xml file of the tool
+			<!-- as an example special tools can be enabled by the xml file of the tool
 				<SpecialTool name="fieldLinerHTS31.xml"/>
 			 -->
 			</Setup>
@@ -100,19 +101,16 @@
 			</Setup>
 		</DisallowedSetups>
 	</Mode>
-	<!--AIDriver(5)	
-		currently skipped in courseplay:getIsToolCombiValidForCpMode:getIsToolCombiValidForCpMode()!
-		as every cp driver setup is allowed to use the TransportMode!
-	 -->
+	<!--AIDriver(5) -->
 	<Mode>
 		<AllowedSetups>
 			<Setup>
-
+				<!-- empty enables everything -->
 			</Setup>
 		</AllowedSetups>
 		<DisallowedSetups>
 			<Setup>
-
+				<!-- empty does not disable anything -->
 			</Setup>
 		</DisallowedSetups>
 	</Mode>
@@ -181,7 +179,8 @@
 		</AllowedSetups>
 		<DisallowedSetups>
 			<Setup>
-
+				<!-- this should disable mode 7 for pretty much everything -->
+				<Specialization name="spec_drivable"/>
 			</Setup>
 		</DisallowedSetups>
 	</Mode>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="47">
-	<version>6.03.00035</version>
+	<version>6.03.00036</version>
 	<author><![CDATA[Courseplay.devTeam]]></author>
 	<title><!-- en=English de=German fr=French es=Spanish ru=Russian pl=Polish it=Italian br=Brazilian-Portuguese cs=Chinese(Simplified) ct=Chinese(Traditional) cz=Czech nl=Netherlands hu=Hungary jp=Japanese kr=Korean pt=Portuguese ro=Romanian tr=Turkish -->
 		<en>CoursePlay SIX</en>


### PR DESCRIPTION
Changed mode configuration, empty configs are allowed by default, this
fixes the reversing with trailer in mode 5 issue (#6777)

Fix unloader going round and round the combine when there's
(incorrectly) fruit detected on both sides #6778