### PR TITLE
6.03.00037 Fix for very long implements and offset

### DIFF
--- a/config/VehicleConfigurations.xml
+++ b/config/VehicleConfigurations.xml
@@ -101,7 +101,7 @@ You can define the following custom settings:
     <!--vehicles\gregoireBesson-->
     <Vehicle name="SPSL9.xml"
              toolOffsetX="2.1"
-             turnRadius = "10"
+             turnRadius = "7.5"
              implementWheelAlwaysOnGround = "true"
 			 workingWidth = "10.5"
     />

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="47">
-	<version>6.03.00036</version>
+	<version>6.03.00037</version>
 	<author><![CDATA[Courseplay.devTeam]]></author>
 	<title><!-- en=English de=German fr=French es=Spanish ru=Russian pl=Polish it=Italian br=Brazilian-Portuguese cs=Chinese(Simplified) ct=Chinese(Traditional) cz=Czech nl=Netherlands hu=Hungary jp=Japanese kr=Korean pt=Portuguese ro=Romanian tr=Turkish -->
 		<en>CoursePlay SIX</en>

--- a/toolManager.lua
+++ b/toolManager.lua
@@ -45,6 +45,10 @@ function courseplay:updateOnAttachOrDetach(vehicle)
 	end
 
 	courseplay:resetTools(vehicle)
+
+	-- reset tool offset to the preconfigured value if exists
+	vehicle.cp.settings.toolOffsetX:setToConfiguredValue()
+
 end
 
 --- Set up tool configuration after something is attached or detached
@@ -61,9 +65,6 @@ function courseplay:resetTools(vehicle)
 	courseplay.hud:setReloadPageOrder(vehicle, -1, true);
 
 	courseplay:calculateWorkWidth(vehicle, true);
-
-	-- reset tool offset to the preconfigured value if exists
-	vehicle.cp.settings.toolOffsetX:setToConfiguredValue()
 end;
 
 function courseplay:isAttachedMixer(workTool)


### PR DESCRIPTION
Do not reset tool offset when starting, only on attach (#6781)

Use the back marker offset when constructing the finish row course to make
sure it is long enough even in case of insanely long implements (#6652)