### PR TITLE
Debug channel refactoring

### DIFF
--- a/AIDriver.lua
+++ b/AIDriver.lua
@@ -141,8 +141,8 @@ AIDriver.myStates = {
 --- Create a new driver (usage: aiDriver = AIDriver(vehicle)
 -- @param vehicle to drive. Will set up a course to drive from vehicle.Waypoints
 function AIDriver:init(vehicle)
-	courseplay.debugVehicle(courseplay.DBG_11,vehicle,'AIDriver:init()')
-	self.debugChannel = courseplay.DBG_14
+	courseplay.debugVehicle(courseplay.DBG_AI_DRIVER,vehicle,'AIDriver:init()')
+	self.debugChannel = courseplay.DBG_MODE_5
 	self.mode = courseplay.MODE_TRANSPORT
 	self.states = {}
 	self:initStates(AIDriver.myStates)
@@ -1348,7 +1348,8 @@ function AIDriver:cleanUpMissedTriggerExit() -- at least that's what it seems to
 			-- This is used in case we already registered a tipTrigger but changed the direction and might not be in that tipTrigger when unloading. (Bug Fix)
 			local startReversing = self.course:switchingToReverseAt(self.ppc:getCurrentWaypointIx() - 1)
 			if startReversing then
-				courseplay:debug(string.format(2,"%s: Is starting to reverse. Tip trigger is reset.", nameNum(self.vehicle)), courseplay.DBG_13);
+				courseplay:debug(string.format(2,"%s: Is starting to reverse. Tip trigger is reset.",
+					nameNum(self.vehicle)), courseplay.DBG_REVERSE);
 			end
 
 			local isBGA = t.bunkerSilo ~= nil

--- a/BaleCollectorAIDriver.lua
+++ b/BaleCollectorAIDriver.lua
@@ -37,10 +37,11 @@ BaleCollectorAIDriver.myStates = {
 }
 
 function BaleCollectorAIDriver:init(vehicle)
-	courseplay.debugVehicle(courseplay.DBG_11,vehicle,'BaleCollectorAIDriver:init()')
+	courseplay.debugVehicle(courseplay.DBG_AI_DRIVER,vehicle,'BaleCollectorAIDriver:init()')
 	BaleLoaderAIDriver.init(self, vehicle)
 	self:initStates(BaleCollectorAIDriver.myStates)
 	self.mode = courseplay.MODE_BALE_COLLECTOR
+	self.debugChannel = courseplay.DBG_MODE_7
 	self.fieldId = 0
 	self.bales = {}
 end

--- a/BaleLoaderAIDriver.lua
+++ b/BaleLoaderAIDriver.lua
@@ -57,7 +57,7 @@ end
 
 
 function BaleLoaderAIDriver:init(vehicle)
-	courseplay.debugVehicle(courseplay.DBG_11,vehicle,'BaleLoaderAIDriver:init()')
+	courseplay.debugVehicle(courseplay.DBG_AI_DRIVER,vehicle,'BaleLoaderAIDriver:init()')
 	UnloadableFieldworkAIDriver.init(self, vehicle)
 	self.baleLoader = AIDriverUtil.getImplementWithSpecialization(vehicle, BaleLoader)
 	self:debug('baleloader %s', tostring(self.baleLoader))

--- a/BaleWrapperAIDriver.lua
+++ b/BaleWrapperAIDriver.lua
@@ -20,7 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 BaleWrapperAIDriver = CpObject(BalerAIDriver)
 
 function BaleWrapperAIDriver:init(vehicle)
-	courseplay.debugVehicle(courseplay.DBG_11,vehicle,'BaleWrapperAIDriver:init()')
+	courseplay.debugVehicle(courseplay.DBG_AI_DRIVER,vehicle,'BaleWrapperAIDriver:init()')
 	-- the only reason this is derived from BalerAIDriver is that some wrappers are also balers. Our concept
 	-- derived classes may not fly when there are multiple specializations to handle, if we had a bale loader
 	-- which is also a bale wrapper then we would probably have to put everything back into the baler.

--- a/BalerAIDriver.lua
+++ b/BalerAIDriver.lua
@@ -20,7 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 BalerAIDriver = CpObject(UnloadableFieldworkAIDriver)
 
 function BalerAIDriver:init(vehicle)
-	courseplay.debugVehicle(courseplay.DBG_11,vehicle,'BalerAIDriver:init()')
+	courseplay.debugVehicle(courseplay.DBG_AI_DRIVER,vehicle,'BalerAIDriver:init()')
 	UnloadableFieldworkAIDriver.init(self, vehicle)
 	self.baler = AIDriverUtil.getAIImplementWithSpecialization(vehicle, Baler)
 	if self.baler then

--- a/BunkersiloManager.lua
+++ b/BunkersiloManager.lua
@@ -1,7 +1,7 @@
 ---@class BunkerSiloManager
 BunkerSiloManager = CpObject()
 
-BunkerSiloManager.debugChannel = 10
+BunkerSiloManager.debugChannel = courseplay.DBG_MODE_10
 
 BunkerSiloManager.MODE = {}
 BunkerSiloManager.MODE.COMPACTING = 0 --LevelCompactAIDriver compacting without shield

--- a/CombineAIDriver.lua
+++ b/CombineAIDriver.lua
@@ -57,7 +57,7 @@ CombineAIDriver.turnTypes = {
 CombineAIDriver.isACombineAIDriver = true
 
 function CombineAIDriver:init(vehicle)
-	courseplay.debugVehicle(courseplay.DBG_11, vehicle, 'CombineAIDriver:init()')
+	courseplay.debugVehicle(courseplay.DBG_AI_DRIVER, vehicle, 'CombineAIDriver:init()')
 	UnloadableFieldworkAIDriver.init(self, vehicle)
 	self:initStates(CombineAIDriver.myStates)
 	self.fruitLeft, self.fruitRight = 0, 0

--- a/CombineUnloadAIDriver.lua
+++ b/CombineUnloadAIDriver.lua
@@ -115,10 +115,10 @@ CombineUnloadAIDriver.myStates = {
 
 --- Constructor
 function CombineUnloadAIDriver:init(vehicle)
-	courseplay.debugVehicle(courseplay.DBG_11,vehicle,'CombineUnloadAIDriver:init()')
+	courseplay.debugVehicle(courseplay.DBG_AI_DRIVER,vehicle,'CombineUnloadAIDriver:init()')
 	self.assignedCombinesSetting = AssignedCombinesSetting(vehicle)
 	AIDriver.init(self, vehicle)
-	self.debugChannel = courseplay.DBG_MODE_2_3
+	self.debugChannel = courseplay.DBG_MODE_2
 	self.mode = courseplay.MODE_COMBI
 	self:initStates(CombineUnloadAIDriver.myStates)
 	self.combineOffset = 0

--- a/CombineUnloadManager.lua
+++ b/CombineUnloadManager.lua
@@ -40,8 +40,6 @@ at the moment.
 ---@class CombineUnloadmanager
 CombineUnloadManager = CpObject()
 
-CombineUnloadManager.debugChannel = 4
-
 -- Constructor
 function CombineUnloadManager:init()
 	self.combines = {}
@@ -61,8 +59,15 @@ function CombineUnloadManager:addNewCombines()
 	end
 end
 
+--- Debug is enabled in mode 2 and 3
+function CombineUnloadManager:debugEnabled()
+	return courseplay.debugChannels[courseplay.DBG_MODE_2] or courseplay.debugChannels[courseplay.DBG_MODE_3]
+end
+
 function CombineUnloadManager:debug(...)
-	courseplay.debugFormat(self.debugChannel, 'CombineUnloadManager: ' .. string.format( ... ))
+	if self:debugEnabled() then
+		courseplay.debugFormat(courseplay.DBG_MODE_2, 'CombineUnloadManager: ' .. string.format( ... ))
+	end
 end
 
 function CombineUnloadManager:debugSparse(...)
@@ -354,7 +359,7 @@ function CombineUnloadManager:updateCombinesAttributes()
 		attributes.fillLevelPct = self:getCombinesFillLevelPercent(combine)
 		attributes.fillLevel = self:getCombinesFillLevel(combine)
 		self:updateFillSpeed(combine,attributes)
-		if courseplay.debugChannels[self.debugChannel] then
+		if self:debugEnabled() then
 			renderText(0.1,0.175+(0.02*number) ,0.015,
 					string.format("%s: leftOK: %s; rightOK:%s numUnloaders:%d",
 							nameNum(combine), tostring(attributes.leftOkToDrive), tostring(attributes.rightOKToDrive),

--- a/CpManager.lua
+++ b/CpManager.lua
@@ -890,12 +890,10 @@ end;
 --FieldScan startup dialog and github info
 function CpManager:showYesNoDialogue(title, text, callbackFn)
 	-- don't show anything if the tutorial dialog is open (it takes a while until is isOpen shows true after startup, hence the clock)
-	--courseplay.debugFormat(courseplay.DBG_12, "clock %d %s", courseplay.clock, tostring(g_gui.guis.YesNoDialog.target and g_gui.guis.YesNoDialog.target.isOpen))
 	if courseplay.clock < 2000 or (g_gui.guis.YesNoDialog.target and g_gui.guis.YesNoDialog.target.isOpen) then
 		return
 	end
-	--courseplay.debugFormat(courseplay.DBG_12, text)
-	local text =string.format("%s\n %s",courseplay:loc('COURSEPLAY_YES_NO_FIELDSCAN'),courseplay:loc('COURSEPLAY_SUPPORT_INFO')) 
+	local text =string.format("%s\n %s",courseplay:loc('COURSEPLAY_YES_NO_FIELDSCAN'),courseplay:loc('COURSEPLAY_SUPPORT_INFO'))
 	g_gui:showYesNoDialog({text=text, title=title, callback=callbackFn, target=self})
 end;
 

--- a/FieldSupplyAIDriver.lua
+++ b/FieldSupplyAIDriver.lua
@@ -39,7 +39,8 @@ function FieldSupplyAIDriver:init(vehicle)
 	self.triggerHandler.driveOnAtFillLevel = settings.driveOnAtFillLevel
 	self:initStates(FieldSupplyAIDriver.myStates)
 	self.supplyState = self.states.ON_REFILL_COURSE
-	self.mode=courseplay.MODE_FIELD_SUPPLY 
+	self.mode=courseplay.MODE_FIELD_SUPPLY
+	self.debugChannel = courseplay.DBG_MODE_8
 	self:setHudContent()
 end
 

--- a/FieldworkAIDriver.lua
+++ b/FieldworkAIDriver.lua
@@ -49,10 +49,10 @@ FieldworkAIDriver.myStates = {
 -- through multiple level of inheritances therefore we must explicitly call
 -- the base class ctr.
 function FieldworkAIDriver:init(vehicle)
-	courseplay.debugVehicle(courseplay.DBG_11,vehicle,'FieldworkAIDriver:init()')
+	courseplay.debugVehicle(courseplay.DBG_AI_DRIVER,vehicle,'FieldworkAIDriver:init()')
 	AIDriver.init(self, vehicle)
 	self:initStates(FieldworkAIDriver.myStates)
-	self.debugChannel = courseplay.DBG_14
+	self.debugChannel = courseplay.DBG_MODE_4
 	-- waypoint index on main (fieldwork) course where we aborted the work before going on
 	-- an unload/refill course
 	self.aiDriverData.continueFieldworkAtWaypoint = 1

--- a/FillableFieldworkAIDriver.lua
+++ b/FillableFieldworkAIDriver.lua
@@ -33,10 +33,11 @@ FillableFieldworkAIDriver.myStates = {
 }
 
 function FillableFieldworkAIDriver:init(vehicle)
-	courseplay.debugVehicle(courseplay.DBG_11,vehicle,'FillableFieldworkAIDriver:init()')
+	courseplay.debugVehicle(courseplay.DBG_AI_DRIVER,vehicle,'FillableFieldworkAIDriver:init()')
 	FieldworkAIDriver.init(self, vehicle)
 	self:initStates(FillableFieldworkAIDriver.myStates)
 	self.mode = courseplay.MODE_SEED_FERTILIZE
+	self.debugChannel = courseplay.DBG_MODE_4
 	self.refillState = self.states.TO_BE_REFILLED
 	self.lastTotalFillLevel = math.huge
 end

--- a/GrainTransportAIDriver.lua
+++ b/GrainTransportAIDriver.lua
@@ -21,9 +21,10 @@ GrainTransportAIDriver = CpObject(AIDriver)
 
 --- Constructor
 function GrainTransportAIDriver:init(vehicle)
-	courseplay.debugVehicle(courseplay.DBG_11,vehicle,'GrainTransportAIDriver:init()')
+	courseplay.debugVehicle(courseplay.DBG_AI_DRIVER,vehicle,'GrainTransportAIDriver:init()')
 	AIDriver.init(self, vehicle)
 	self.mode = courseplay.MODE_GRAIN_TRANSPORT
+	self.debugChannel = courseplay.DBG_MODE_1
 	self.totalFillCapacity = 0
 end
 

--- a/LevelCompactAIDriver.lua
+++ b/LevelCompactAIDriver.lua
@@ -428,9 +428,9 @@ function LevelCompactAIDriver:isStuck()
 	if self:doesNotMove() then
 		if self.vehicle.cp.timers.slipping == nil or self.vehicle.cp.timers.slipping == 0 then
 			courseplay:setCustomTimer(self.vehicle, 'slipping', 3);
-			--courseplay:debug(('%s: setCustomTimer(..., "slippingStage", courseplay.DBG_TRAFFIC)'):format(nameNum(self.vehicle)), courseplay.DBG_10);
+			--courseplay:debug(('%s: setCustomTimer(..., "slippingStage", courseplay.DBG_TRAFFIC)'):format(nameNum(self.vehicle)), courseplay.DBG_MODE_10);
 		elseif courseplay:timerIsThrough(self.vehicle, 'slipping') then
-			--courseplay:debug(('%s: timerIsThrough(..., "slippingStage") -> return isStuck(), reset timer'):format(nameNum(self.vehicle)), courseplay.DBG_10);
+			--courseplay:debug(('%s: timerIsThrough(..., "slippingStage") -> return isStuck(), reset timer'):format(nameNum(self.vehicle)), courseplay.DBG_MODE_10);
 			courseplay:resetCustomTimer(self.vehicle, 'slipping');
 			self:debug("dropout isStuck")
 			return true
@@ -553,7 +553,7 @@ function LevelCompactAIDriver:getSpeed()
 end
 
 function LevelCompactAIDriver:debug(...)
-	courseplay.debugVehicle(courseplay.DBG_10, self.vehicle, ...)
+	courseplay.debugVehicle(courseplay.DBG_MODE_10, self.vehicle, ...)
 end
 
 function LevelCompactAIDriver:checkSilo()
@@ -609,7 +609,7 @@ function LevelCompactAIDriver:getLevelerNode(blade)
 end
 
 function LevelCompactAIDriver:printMap()
-	if courseplay.debugChannels[courseplay.DBG_10] and self.bunkerSiloManager.siloMap then
+	if courseplay.debugChannels[courseplay.DBG_MODE_10] and self.bunkerSiloManager.siloMap then
 		for _, line in pairs(self.bunkerSiloManager.siloMap) do
 			local printString = ""
 			for _, fillUnit in pairs(line) do
@@ -761,7 +761,7 @@ function LevelCompactAIDriver:getValidBackImplement()
 end
 
 function LevelCompactAIDriver:isDebugActive()
-	return courseplay.debugChannels[courseplay.DBG_10]
+	return courseplay.debugChannels[courseplay.DBG_MODE_10]
 end
 
 

--- a/LevelCompactAIDriver.lua
+++ b/LevelCompactAIDriver.lua
@@ -48,11 +48,11 @@ LevelCompactAIDriver.myStates = {
 
 --- Constructor
 function LevelCompactAIDriver:init(vehicle)
-	courseplay.debugVehicle(courseplay.DBG_11,vehicle,'LevelCompactAIDriver:init')
+	courseplay.debugVehicle(courseplay.DBG_AI_DRIVER,vehicle,'LevelCompactAIDriver:init')
 	AIDriver.init(self, vehicle)
 	self:initStates(LevelCompactAIDriver.myStates)
 	self.mode = courseplay.MODE_BUNKERSILO_COMPACTER
-	self.debugChannel = courseplay.DBG_10
+	self.debugChannel = courseplay.DBG_MODE_10
 	self.refSpeed = 10
 	self.fillUpState = self.states.PUSH
 	self:setLevelerWorkWidth()

--- a/OverloaderAIDriver.lua
+++ b/OverloaderAIDriver.lua
@@ -30,9 +30,9 @@ function OverloaderAIDriver:init(vehicle)
     --there seems to be a bug, where "vehicle" is not always set once start is pressed
 	CombineUnloadAIDriver.init(self, vehicle)
     self:initStates(OverloaderAIDriver.myStates)
+    self.mode = courseplay.MODE_OVERLOADER
 	self.debugChannel = courseplay.DBG_MODE_3
     self:debug('OverloaderAIDriver:init()')
-    self.mode = courseplay.MODE_OVERLOADER
 	self.unloadCourseState = self.states.ENROUTE
     self.nearOverloadPoint = false
 end

--- a/OverloaderAIDriver.lua
+++ b/OverloaderAIDriver.lua
@@ -30,6 +30,7 @@ function OverloaderAIDriver:init(vehicle)
     --there seems to be a bug, where "vehicle" is not always set once start is pressed
 	CombineUnloadAIDriver.init(self, vehicle)
     self:initStates(OverloaderAIDriver.myStates)
+	self.debugChannel = courseplay.DBG_MODE_3
     self:debug('OverloaderAIDriver:init()')
     self.mode = courseplay.MODE_OVERLOADER
 	self.unloadCourseState = self.states.ENROUTE

--- a/PlowAIDriver.lua
+++ b/PlowAIDriver.lua
@@ -30,10 +30,11 @@ PlowAIDriver.myStates = {
 }
 
 function PlowAIDriver:init(vehicle)
-	courseplay.debugVehicle(courseplay.DBG_11,vehicle,'PlowAIDriver:init()')
+	courseplay.debugVehicle(courseplay.DBG_AI_DRIVER,vehicle,'PlowAIDriver:init()')
 	FieldworkAIDriver.init(self, vehicle)
 	self:initStates(PlowAIDriver.myStates)
 	self.mode = courseplay.MODE_FIELDWORK
+	self.debugChannel = courseplay.DBG_MODE_6
 	self.plow = AIDriverUtil.getAIImplementWithSpecialization(vehicle, Plow)
 	self:setOffsetX()
 	if self:hasRotatablePlow() then

--- a/ProximitySensor.lua
+++ b/ProximitySensor.lua
@@ -68,7 +68,7 @@ function ProximitySensor:update()
                 --bitOR(AIVehicleUtil.COLLISION_MASK, 0x1f0))
         --cpDebug:drawLine(x, y + self.height, z, 0, 1, 0, x + 5 * nx, y + self.height + 5 * ny, z + 5 * nz)
     end
-    if courseplay.debugChannels[courseplay.DBG_12] and self.distanceOfClosestObject <= self.range then
+    if courseplay.debugChannels[courseplay.DBG_TRAFFIC] and self.distanceOfClosestObject <= self.range then
         local green = self.distanceOfClosestObject / self.range
         local red = 1 - green
         cpDebug:drawLine(x, y + self.height, z, red, green, 0, self.closestObjectX, self.closestObjectY, self.closestObjectZ)
@@ -105,7 +105,7 @@ function ProximitySensor:getClosestRootVehicle()
 end
 
 function ProximitySensor:showDebugInfo()
-    if not courseplay.debugChannels[courseplay.DBG_12] then return end
+    if not courseplay.debugChannels[courseplay.DBG_TRAFFIC] then return end
     local text = string.format('%.1f ', self.distanceOfClosestObject)
     if self.objectId then
         local object = g_currentMission:getNodeObject(self.objectId)
@@ -167,7 +167,7 @@ function ProximitySensorPack:init(name, vehicle, ppc, node, range, height, direc
 end
 
 function ProximitySensorPack:debug(...)
-    courseplay.debugVehicle(courseplay.DBG_12, self.vehicle, ...)
+    courseplay.debugVehicle(courseplay.DBG_TRAFFIC, self.vehicle, ...)
 end
 
 function ProximitySensorPack:adjustForwardPosition()
@@ -210,7 +210,7 @@ function ProximitySensorPack:update()
     self:callForAllSensors(ProximitySensor.update)
 
     -- show the position of the pack
-    if courseplay.debugChannels[courseplay.DBG_12] then
+    if courseplay.debugChannels[courseplay.DBG_TRAFFIC] then
         local x, y, z = getWorldTranslation(self.node)
         local x1, y1, z1 = localToWorld(self.node, 0, 0, 0.5)
         cpDebug:drawLine(x, y, z, 0, 0, 1, x, y + 3, z)

--- a/PurePursuitController.lua
+++ b/PurePursuitController.lua
@@ -109,7 +109,7 @@ function PurePursuitController:delete()
 end
 
 function PurePursuitController:debug(...)
-	courseplay.debugVehicle(courseplay.DBG_12, self.vehicle, 'PPC: ' .. string.format( ... ))
+	courseplay.debugVehicle(courseplay.DBG_PPC, self.vehicle, 'PPC: ' .. string.format( ... ))
 end
 
 function PurePursuitController:debugSparse(...)
@@ -372,7 +372,7 @@ function PurePursuitController:findRelevantSegment()
 			self:debug('relevant waypoint: %d, crosstrack error: %.1f', self.relevantWpNode.ix, self.crossTrackError)
 		end
 	end
-	if courseplay.debugChannels[courseplay.DBG_12] then
+	if courseplay.debugChannels[courseplay.DBG_PPC] then
 		cpDebug:drawLine(px, py + 3, pz, 1, 1, 0, px, py + 1, pz);
 		DebugUtil.drawDebugNode(self.relevantWpNode.node, string.format('ix = %d\nrelevant\nnode', self.relevantWpNode.ix))
 		DebugUtil.drawDebugNode(self.projectedPosNode, 'projected\nvehicle\nposition')
@@ -435,7 +435,7 @@ function PurePursuitController:findGoalPoint()
 			self:showGoalpointDiag(2, 'common case, ix=%d, q1=%.1f, q2=%.1f la=%.1f', ix, q1, q2, self.lookAheadDistance)
 			-- current waypoint is the waypoint at the end of the path segment
 			self:setCurrentWaypoint(ix + 1)
-			--courseplay.debugVehicle(courseplay.DBG_12, self.vehicle, "PPC: %d, p=%.1f", self.currentWpNode.ix, p)
+			--courseplay.debugVehicle(courseplay.DBG_PPC, self.vehicle, "PPC: %d, p=%.1f", self.currentWpNode.ix, p)
 			break
 		end
 
@@ -484,7 +484,7 @@ function PurePursuitController:findGoalPoint()
 	node1:destroy()
 	node2:destroy()
 	
-	if courseplay.debugChannels[courseplay.DBG_12] then
+	if courseplay.debugChannels[courseplay.DBG_PPC] then
 		local gx, gy, gz = localToWorld(self.goalWpNode.node, 0, 0, 0)
 		cpDebug:drawLine(gx, gy + 3, gz, 0, 1, 0, gx, gy + 1, gz);
 		DebugUtil.drawDebugNode(self.currentWpNode.node, string.format('ix = %d\ncurrent\nwaypoint', self.currentWpNode.ix))
@@ -525,7 +525,7 @@ end
 
 function PurePursuitController:showGoalpointDiag(case, ...)
 	local diagText = string.format(...)
-	if courseplay.debugChannels[courseplay.DBG_12] then
+	if courseplay.debugChannels[courseplay.DBG_PPC] then
 		DebugUtil.drawDebugNode(self.goalWpNode.node, diagText)
 		DebugUtil.drawDebugNode(self.controlledNode, 'controlled')
 	end

--- a/ShovelModeAIDriver.lua
+++ b/ShovelModeAIDriver.lua
@@ -44,7 +44,6 @@ TODO:
 ]]--
 
 ---@class ShovelModeAIDriver : AIDriver
-
 ShovelModeAIDriver = CpObject(AIDriver)
 
 ShovelModeAIDriver.myStates = {
@@ -70,11 +69,12 @@ ShovelModeAIDriver.SHOVEL_POSITIONS.UNLOADING = 4
 
 --- Constructor
 function ShovelModeAIDriver:init(vehicle)
-	courseplay.debugVehicle(courseplay.DBG_11,vehicle,'ShovelModeAIDriver:init')
+	courseplay.debugVehicle(courseplay.DBG_AI_DRIVER,vehicle,'ShovelModeAIDriver:init')
 	AIDriver.init(self, vehicle)
 	self:initStates(ShovelModeAIDriver.myStates)
 	--self.mode = courseplay.MODE_SHOVEL_FILL_AND_EMPTY
 	self.shovelState = self.states.STATE_TRANSPORT
+	self.debugChannel = courseplay.DBG_MODE_9
 	self.refSpeed = 15
 end
 

--- a/ShovelModeAIDriver.lua
+++ b/ShovelModeAIDriver.lua
@@ -72,7 +72,7 @@ function ShovelModeAIDriver:init(vehicle)
 	courseplay.debugVehicle(courseplay.DBG_AI_DRIVER,vehicle,'ShovelModeAIDriver:init')
 	AIDriver.init(self, vehicle)
 	self:initStates(ShovelModeAIDriver.myStates)
-	--self.mode = courseplay.MODE_SHOVEL_FILL_AND_EMPTY
+	self.mode = courseplay.MODE_SHOVEL_FILL_AND_EMPTY
 	self.shovelState = self.states.STATE_TRANSPORT
 	self.debugChannel = courseplay.DBG_MODE_9
 	self.refSpeed = 15
@@ -175,7 +175,7 @@ function ShovelModeAIDriver:renderText(y,text,xOffset)
 end
 
 function ShovelModeAIDriver:isDebugActive()
-	return courseplay.debugChannels[courseplay.DBG_10]
+	return courseplay.debugChannels[courseplay.DBG_MODE_9]
 end
 
 function ShovelModeAIDriver:drive(dt)
@@ -349,9 +349,9 @@ function ShovelModeAIDriver:isStuck()
 	if self:doesNotMove() then
 		if self.vehicle.cp.timers.slipping == nil or self.vehicle.cp.timers.slipping == 0 then
 			courseplay:setCustomTimer(self.vehicle, 'slipping', 2);
-			--courseplay:debug(('%s: setCustomTimer(..., "slippingStage", courseplay.DBG_TRAFFIC)'):format(nameNum(self.vehicle)), courseplay.DBG_10);
+			--courseplay:debug(('%s: setCustomTimer(..., "slippingStage", courseplay.DBG_TRAFFIC)'):format(nameNum(self.vehicle)), courseplay.DBG_MODE_9);
 		elseif courseplay:timerIsThrough(self.vehicle, 'slipping') then
-			--courseplay:debug(('%s: timerIsThrough(..., "slippingStage") -> return isStuck(), reset timer'):format(nameNum(self.vehicle)), courseplay.DBG_10);
+			--courseplay:debug(('%s: timerIsThrough(..., "slippingStage") -> return isStuck(), reset timer'):format(nameNum(self.vehicle)), courseplay.DBG_MODE_9);
 			courseplay:resetCustomTimer(self.vehicle, 'slipping');
 			self:debug("dropout isStuck")
 			return true
@@ -658,7 +658,7 @@ function ShovelModeAIDriver:searchForUnloadingObjectRaycast()
 		if self.shovelState == self.states.STATE_WAIT_FOR_TARGET then
 			local x,y,z = localToWorld(node.node,0,8,i/2);
 			raycastAll(x, y, z, lx, ly, lz, "searchForUnloadingObjectRaycastCallback", 10, self);
-			if courseplay.debugChannels[courseplay.DBG_10] then
+			if courseplay.debugChannels[courseplay.DBG_MODE_9] then
 				cpDebug:drawLine(x, y, z, 1, 0, 0, x+lx*10, y+ly*10, z+lz*10);
 			end;
 		end
@@ -800,7 +800,7 @@ function ShovelModeAIDriver:findNextRevWaypoint(currentPoint)
 end
 
 function ShovelModeAIDriver:debug(...)
-	courseplay.debugVehicle(courseplay.DBG_10, self.vehicle, ...)
+	courseplay.debugVehicle(courseplay.DBG_MODE_9, self.vehicle, ...)
 end
 
 function ShovelModeAIDriver:setShovelState(state, extraText)

--- a/TriggerHandler.lua
+++ b/TriggerHandler.lua
@@ -657,7 +657,7 @@ function TriggerHandler:activateTriggerForVehicle(trigger, vehicle)
 	--Override farm id to match the calling vehicle (fixes issue when obtaining fill levels)
 	local overriddenFarmIdFunc = function()
 		local ownerFarmId = vehicle:getOwnerFarmId()
-		courseplay.debugVehicle(courseplay.DBG_19, vehicle, 'Overriding farm id during trigger activation to %d', ownerFarmId);
+		courseplay.debugVehicle(courseplay.DBG_TRIGGERS, vehicle, 'Overriding farm id during trigger activation to %d', ownerFarmId);
 		return ownerFarmId;
 	end
 	g_currentMission.getFarmId = overriddenFarmIdFunc;

--- a/UnloadableFieldworkAIDriver.lua
+++ b/UnloadableFieldworkAIDriver.lua
@@ -34,10 +34,11 @@ UnloadableFieldworkAIDriver.fillLevelFullPercentage = UnloadableFieldworkAIDrive
 UnloadableFieldworkAIDriver.fillLevelEmptyPercentage = 0.1
 
 function UnloadableFieldworkAIDriver:init(vehicle)
-	courseplay.debugVehicle(courseplay.DBG_11,vehicle,'UnloadableFieldworkAIDriver:init()')
+	courseplay.debugVehicle(courseplay.DBG_AI_DRIVER,vehicle,'UnloadableFieldworkAIDriver:init()')
 	FieldworkAIDriver.init(self, vehicle)
 	self:initStates(UnloadableFieldworkAIDriver.myStates)
 	self.mode = courseplay.MODE_FIELDWORK
+	self.debugChannel = courseplay.DBG_MODE_6
 	self.stopImplementsWhileUnloadOrRefillOnField = false
 	self.refillUntilPct = vehicle.cp.settings.refillUntilPct
 end

--- a/ValidModeSetupHandler.lua
+++ b/ValidModeSetupHandler.lua
@@ -92,11 +92,11 @@ function ValidModeSetupHandler:isModeValid(mode,object)
 	if validData then 
 		if validData.allowedSetups then 
 			isAllowedOkay = self:isSetupAllowedValid(validData.allowedSetups,object)
-			courseplay.debugVehicle(courseplay.DBG_18,object,"allowedSetups, mode: %d, isAllowedOkay: %s",mode,tostring(isAllowedOkay))
+			courseplay.debugVehicle(courseplay.DBG_HUD,object,"allowedSetups, mode: %d, isAllowedOkay: %s",mode,tostring(isAllowedOkay))
 		end
 		if validData.disallowedSetups then 
 			isDisallowedOkay = self:isSetupDisallowedValid(validData.disallowedSetups,object)
-			courseplay.debugVehicle(courseplay.DBG_18,object,"disallowedSetup, mode: %d,, isDisallowedOkay: %s",mode,tostring(isDisallowedOkay))
+			courseplay.debugVehicle(courseplay.DBG_HUD,object,"disallowedSetup, mode: %d,, isDisallowedOkay: %s",mode,tostring(isDisallowedOkay))
 		end
 	else 
 		courseplay.info("ValidModeSetupHandler, validData==nil !!")

--- a/Waypoint.lua
+++ b/Waypoint.lua
@@ -177,7 +177,7 @@ end
 function WaypointNode:setToWaypoint(course, ix, suppressLog)
 	local newIx = math.min(ix, course:getNumberOfWaypoints())
 	if newIx ~= self.ix and self.logChanges and not suppressLog then
-		courseplay.debugVehicle(courseplay.DBG_12, course.vehicle, 'PPC: %s waypoint index %d', getName(self.node), ix)
+		courseplay.debugVehicle(courseplay.DBG_PPC, course.vehicle, 'PPC: %s waypoint index %d', getName(self.node), ix)
 	end
 	self.ix = newIx
 	local x, y, z = course:getWaypointPosition(self.ix)
@@ -197,7 +197,7 @@ function WaypointNode:setToWaypointOrBeyond(course, ix, distance)
 		local nx, ny, nz = localToWorld(self.node, 0, 0, distance)
 		setTranslation(self.node, nx, ny, nz)
 		if self.logChanges and self.mode and self.mode ~= WaypointNode.MODE_LAST_WP then
-			courseplay.debugVehicle(courseplay.DBG_12, course.vehicle, 'PPC: last waypoint reached, moving node beyond last: %s', getName(self.node))
+			courseplay.debugVehicle(courseplay.DBG_PPC, course.vehicle, 'PPC: last waypoint reached, moving node beyond last: %s', getName(self.node))
 		end
 		
 		self.mode = WaypointNode.MODE_LAST_WP
@@ -213,7 +213,7 @@ function WaypointNode:setToWaypointOrBeyond(course, ix, distance)
 		local nx, ny, nz = localToWorld(self.node, 0, 0, distance)
 		setTranslation(self.node, nx, ny, nz)
 		if self.logChanges and self.mode and self.mode ~= WaypointNode.MODE_SWITCH_DIRECTION then
-			courseplay.debugVehicle(courseplay.DBG_12, course.vehicle, 'PPC: switching direction at %d, moving node beyond it: %s', ix, getName(self.node))
+			courseplay.debugVehicle(courseplay.DBG_PPC, course.vehicle, 'PPC: switching direction at %d, moving node beyond it: %s', ix, getName(self.node))
 		end
 		self.mode = WaypointNode.MODE_SWITCH_DIRECTION
 	elseif course:mustReach(ix) then
@@ -225,12 +225,12 @@ function WaypointNode:setToWaypointOrBeyond(course, ix, distance)
 		local nx, ny, nz = localToWorld(self.node, 0, 0, distance)
 		setTranslation(self.node, nx, ny, nz)
 		if self.logChanges and self.mode and self.mode ~= WaypointNode.MODE_MUST_REACH then
-			courseplay.debugVehicle(courseplay.DBG_12, course.vehicle, 'PPC: must reach next waypoint, moving node beyond it: %s', getName(self.node))
+			courseplay.debugVehicle(courseplay.DBG_PPC, course.vehicle, 'PPC: must reach next waypoint, moving node beyond it: %s', getName(self.node))
 		end
 		self.mode = WaypointNode.MODE_MUST_REACH
 	else
 		if self.logChanges and self.mode and self.mode ~= WaypointNode.MODE_NORMAL then
-			courseplay.debugVehicle(courseplay.DBG_12, course.vehicle, 'PPC: normal waypoint (not last, no direction change: %s', getName(self.node))
+			courseplay.debugVehicle(courseplay.DBG_PPC, course.vehicle, 'PPC: normal waypoint (not last, no direction change: %s', getName(self.node))
 		end
 		self.mode = WaypointNode.MODE_NORMAL
 		self:setToWaypoint(course, ix)
@@ -286,7 +286,6 @@ function Course:initWaypoints()
 			local result = rawget(tbl, key)
 			if not result and type(key) == "number" then
 				result = rawget(tbl, math.min(math.max(1, key), #tbl))
-				--courseplay.debugFormat(courseplay.DBG_14, 'Invalid index %s, clamped to %s', key, math.min(math.max(1, key), #tbl))
 			end
 			return result
 		end
@@ -427,7 +426,7 @@ function Course:enrichWaypointData()
 			turnFound = true
 		end
 	end
-	courseplay.debugFormat(courseplay.DBG_12, 'Course with %d waypoints created/updated, %.1f meters, %d turns', #self.waypoints, self.length, self.totalTurns)
+	courseplay.debugFormat(courseplay.DBG_COURSES, 'Course with %d waypoints created/updated, %.1f meters, %d turns', #self.waypoints, self.length, self.totalTurns)
 end
 
 function Course:calculateRadius(ix)
@@ -763,7 +762,6 @@ function Course:getDistanceToFirstUpDownRowWaypoint(ix)
 	for i = ix, #self.waypoints - 1 do
 		isConnectingTrack = isConnectingTrack or self.waypoints[i].isConnectingTrack
 		d = d + self.waypoints[i].dToNext
-		--courseplay.debugFormat(courseplay.DBG_12, 'd = %.1f i = %d, lane = %s', d, i, tostring(self.waypoints[i].lane))
 		if self.waypoints[i].lane and not self.waypoints[i + 1].lane and isConnectingTrack then
 			return d, i + 1
 		end
@@ -971,7 +969,7 @@ function Course:getNextFwdWaypointIx(ix)
 			return i
 		end
 	end
-	courseplay.debugFormat(courseplay.DBG_12, 'Course: could not find next forward waypoint after %d', ix)
+	courseplay.debugFormat(courseplay.DBG_COURSES, 'Course: could not find next forward waypoint after %d', ix)
 	return ix
 end
 
@@ -985,7 +983,7 @@ function Course:getNextFwdWaypointIxFromVehiclePosition(ix, vehicleNode, lookAhe
 			end
 		end
 	end
-	courseplay.debugFormat(courseplay.DBG_12, 'Course: could not find next forward waypoint after %d', ix)
+	courseplay.debugFormat(courseplay.DBG_COURSES, 'Course: could not find next forward waypoint after %d', ix)
 	return ix
 end
 
@@ -999,7 +997,7 @@ function Course:getNextRevWaypointIxFromVehiclePosition(ix, vehicleNode, lookAhe
 			end
 		end
 	end
-	courseplay.debugFormat(courseplay.DBG_12, 'Course: could not find next forward waypoint after %d', ix)
+	courseplay.debugFormat(courseplay.DBG_COURSES, 'Course: could not find next forward waypoint after %d', ix)
 	return ix
 end
 
@@ -1352,7 +1350,7 @@ function Course:calculateOffsetCourse(nVehicles, position, width, useSameTurnWid
 		origHeadlandsCourse, ix = self:getNextHeadlandSection(nil, ix)
 		if origHeadlandsCourse:getNumberOfWaypoints() > 0 then
 			if origHeadlandsCourse:getNumberOfWaypoints() > 2 then
-				courseplay.debugFormat(courseplay.DBG_COURSE_GENERATOR, 'Headland section to %d', ix)
+				courseplay.debugFormat(courseplay.DBG_COURSES, 'Headland section to %d', ix)
 				courseGenerator.pointsToXyInPlace(origHeadlandsCourse.waypoints)
 				local origHeadlands = Polyline:new(origHeadlandsCourse.waypoints)
 				origHeadlands:calculateData()
@@ -1368,36 +1366,36 @@ function Course:calculateOffsetCourse(nVehicles, position, width, useSameTurnWid
 					offsetHeadlands:calculateData()
 					self:markAsHeadland(offsetHeadlands)
 					if origHeadlandsCourse:isTurnStartAtIx(origHeadlandsCourse:getNumberOfWaypoints()) then
-						courseplay.debugFormat(courseplay.DBG_COURSE_GENERATOR, 'Original headland transitioned to the center with a turn, adding a turn start to the offset one')
+						courseplay.debugFormat(courseplay.DBG_COURSES, 'Original headland transitioned to the center with a turn, adding a turn start to the offset one')
 						offsetHeadlands[#offsetHeadlands].turnStart = true
 					end
 					addTurnsToCorners(offsetHeadlands, math.rad(60), true)
 					courseGenerator.pointsToXzInPlace(offsetHeadlands)
 					offsetCourse:appendWaypoints(offsetHeadlands)
-					courseplay.debugFormat(courseplay.DBG_COURSE_GENERATOR, 'Headland done %d', ix)
+					courseplay.debugFormat(courseplay.DBG_COURSES, 'Headland done %d', ix)
 				end
 			else
-				courseplay.debugFormat(courseplay.DBG_COURSE_GENERATOR, 'Short headland section to %d', ix)
+				courseplay.debugFormat(courseplay.DBG_COURSES, 'Short headland section to %d', ix)
 				origHeadlandsCourse:offsetUpDownRows(offset, 0)
 				offsetCourse:append(origHeadlandsCourse)
 			end
 		else
 			local upDownCourse
-			courseplay.debugFormat(courseplay.DBG_COURSE_GENERATOR, 'Get next non-headland %d', ix)
+			courseplay.debugFormat(courseplay.DBG_COURSES, 'Get next non-headland %d', ix)
 			upDownCourse, ix = self:getNextNonHeadlandSection(ix)
 			if upDownCourse:getNumberOfWaypoints() > 0 then
-				courseplay.debugFormat(courseplay.DBG_COURSE_GENERATOR, 'Up/down section to %d', ix)
+				courseplay.debugFormat(courseplay.DBG_COURSES, 'Up/down section to %d', ix)
 				upDownCourse:offsetUpDownRows(offset, 0, useSameTurnWidth)
 				offsetCourse:append(upDownCourse)
 			end
 		end
 	end
-	courseplay.debugFormat(courseplay.DBG_COURSE_GENERATOR, 'Original headland length %.0f m, new headland length %.0f m (%.1f %%, %.1f m)',
+	courseplay.debugFormat(courseplay.DBG_COURSES, 'Original headland length %.0f m, new headland length %.0f m (%.1f %%, %.1f m)',
 			self.headlandLength, offsetCourse.headlandLength, 100 * offsetCourse.headlandLength / self.headlandLength,
 			offsetCourse.headlandLength - self.headlandLength)
 	local originalNonHeadlandLength = self.length - self.headlandLength
 	local offsetNonHeadlandLength = offsetCourse.length - offsetCourse.headlandLength
-	courseplay.debugFormat(courseplay.DBG_COURSE_GENERATOR, 'Original non-headland length %.0f m, new non-headland length %.0f m (%.1f %%, %.1f m)',
+	courseplay.debugFormat(courseplay.DBG_COURSES, 'Original non-headland length %.0f m, new non-headland length %.0f m (%.1f %%, %.1f m)',
 			originalNonHeadlandLength, offsetNonHeadlandLength,
 			100 * offsetNonHeadlandLength / originalNonHeadlandLength,
 			offsetNonHeadlandLength - originalNonHeadlandLength)

--- a/base.lua
+++ b/base.lua
@@ -209,7 +209,7 @@ function courseplay:onLoad(savegame)
 	else
 		self.cp.steeringAngle = 30;
 	end
-	courseplay.debugVehicle( courseplay.DBG_COURSE_GENERATOR, self, 'steering angle is %.1f', self.cp.steeringAngle)
+	courseplay.debugVehicle( courseplay.DBG_COURSES, self, 'steering angle is %.1f', self.cp.steeringAngle)
 	if isTruck then
 		self.cp.revSteeringAngle = self.cp.steeringAngle * 0.25;
 	end;
@@ -461,27 +461,9 @@ function courseplay:onDraw()
 			courseplay:showWorkWidth(self);
 		end;
 	end;
-	--DEBUG Speed Setting
-	if courseplay.debugChannels[courseplay.DBG_21] then
-		renderText(0.2, 0.105, 0.02, string.format("mode%d waypointIndex: %d",self.cp.mode,self.cp.waypointIndex));
-		renderText(0.2, 0.075, 0.02, self.cp.speedDebugLine);
-		if self.cp.speedDebugStreet then
-			local mode = "max"
-			local speed = self.cp.speeds.street
-			if self.cp.settings.useRecordingSpeed:is(true) then
-				mode = "wpt"
-				if self.Waypoints and self.Waypoints[self.cp.waypointIndex] and self.Waypoints[self.cp.waypointIndex].speed then
-					speed = self.Waypoints[self.cp.waypointIndex].speed
-				else
-					speed = "no speed"
-				end
-			end			
-			renderText(0.2, 0.045, 0.02, string.format("mode[%s] speed: %s",mode,tostring(speed)));
-		end	
-	end
-	
+
 	--DEBUG SHOW DIRECTIONNODE
-	if courseplay.debugChannels[courseplay.DBG_12] then
+	if courseplay.debugChannels[courseplay.DBG_PPC] then
 		-- For debugging when setting the directionNodeZOffset. (Visual points shown for old node)
 		if self.cp.oldDirectionNode then
 			local ox,oy,oz = getWorldTranslation(self.cp.oldDirectionNode);

--- a/button.lua
+++ b/button.lua
@@ -211,10 +211,10 @@ function courseplay.button:handleHoverAction(vehicle, posX, posY)
 		local upParameter = parameter;
 		local downParameter = upParameter * -1;
 		if Input.isMouseButtonPressed(Input.MOUSE_BUTTON_WHEEL_UP) and button.canScrollUp then
-			courseplay:debug(string.format("%s: MOUSE_BUTTON_WHEEL_UP: %s(%s)", nameNum(vehicle), tostring(button.functionToCall), tostring(upParameter)), courseplay.DBG_18);
+			courseplay:debug(string.format("%s: MOUSE_BUTTON_WHEEL_UP: %s(%s)", nameNum(vehicle), tostring(button.functionToCall), tostring(upParameter)), courseplay.DBG_HUD);
 			self:handleInput(vehicle,upParameter)
 		elseif Input.isMouseButtonPressed(Input.MOUSE_BUTTON_WHEEL_DOWN) and button.canScrollDown then
-			courseplay:debug(string.format("%s: MOUSE_BUTTON_WHEEL_DOWN: %s(%s)", nameNum(vehicle), tostring(button.functionToCall), tostring(downParameter)), courseplay.DBG_18);
+			courseplay:debug(string.format("%s: MOUSE_BUTTON_WHEEL_DOWN: %s(%s)", nameNum(vehicle), tostring(button.functionToCall), tostring(downParameter)), courseplay.DBG_HUD);
 			self:handleInput(vehicle,downParameter)
 		end;
 	end;
@@ -224,7 +224,7 @@ function courseplay.button:handleMouseClick(vehicle)
 	vehicle = vehicle or self.vehicle;
 	local parameter = self.parameter;
 	if courseplay.inputModifierIsPressed and self.modifiedParameter ~= nil then
-		courseplay:debug("self.modifiedParameter = " .. tostring(self.modifiedParameter), courseplay.DBG_18);
+		courseplay:debug("self.modifiedParameter = " .. tostring(self.modifiedParameter), courseplay.DBG_HUD);
 		parameter = self.modifiedParameter;
 	end;
 
@@ -240,7 +240,7 @@ function courseplay.button:handleMouseClick(vehicle)
 		if self.functionToCall == "goToVehicle" then
 			courseplay:executeFunction(vehicle, "goToVehicle", parameter)
 		else
-			courseplay:debug(string.format("%s: MOUSE_BUTTON_ClICKED: %s(%s)", nameNum(vehicle), tostring(self.functionToCall), tostring(parameter)), courseplay.DBG_18);
+			courseplay:debug(string.format("%s: MOUSE_BUTTON_ClICKED: %s(%s)", nameNum(vehicle), tostring(self.functionToCall), tostring(parameter)), courseplay.DBG_HUD);
 			self:handleInput(vehicle,parameter)
 		end
 		-- self:setClicked(false);
@@ -249,7 +249,7 @@ end;
 
 function courseplay.button:handleInput(vehicle,parameter)
 	if self.settingCall then --settingButton
-		courseplay:debug(string.format("%s: handleSettingInput: %s:%s(%s)", nameNum(vehicle),tostring(self.settingCall.name), tostring(self.functionToCall), tostring(parameter)), courseplay.DBG_18);
+		courseplay:debug(string.format("%s: handleSettingInput: %s:%s(%s)", nameNum(vehicle),tostring(self.settingCall.name), tostring(self.functionToCall), tostring(parameter)), courseplay.DBG_HUD);
 		self.settingCall[self.functionToCall](self.settingCall, parameter)	
 		if vehicle:getIsEntered() then
 			g_currentMission.hud.guiSoundPlayer:playSample(GuiSoundPlayer.SOUND_SAMPLES.CLICK)

--- a/course-generator/HybridAStar.lua
+++ b/course-generator/HybridAStar.lua
@@ -72,7 +72,12 @@ function PathfinderInterface:resume(...)
 end
 
 function PathfinderInterface:debug(...)
-    courseGenerator.debug(...)
+	if courseGenerator.isRunningInGame() then
+		courseplay.debugFormat(courseplay.DBG_PATHFINDER, ...)
+	else
+		print(string.format( ...))
+		io.stdout:flush()
+	end
 end
 
 --- Interface definition for pathfinder constraints (for dependency injection of node penalty/validity checks

--- a/course-generator/PathfinderUtil.lua
+++ b/course-generator/PathfinderUtil.lua
@@ -66,7 +66,7 @@ function PathfinderUtil.VehicleData:init(vehicle, withImplements, buffer)
         -- TODO: this should be the attacher joint's offset, not the back of the vehicle.
         self.trailerHitchOffset = self.dRear
         self.trailerHitchLength = AIDriverUtil.getTowBarLength(vehicle)
-    courseplay.debugVehicle(courseplay.DBG_COURSE_GENERATOR, vehicle, 'trailer for the pathfinding is %s, hitch offset is %.1f',
+    courseplay.debugVehicle(courseplay.DBG_PATHFINDER, vehicle, 'trailer for the pathfinding is %s, hitch offset is %.1f',
                 self.trailer:getName(), self.trailerHitchOffset)
     end
     if withImplements then
@@ -90,7 +90,7 @@ function PathfinderUtil.VehicleData:getRectangleForImplement(implement, referenc
         -- we call this offset, and is negative when behind the reference node, positive when in front of it
         -- (need to reverse attacherJointToImplementRoot)
         rootToReferenceNodeOffset = - attacherJointToImplementRoot + referenceToAttacherJoint
-        courseplay.debugFormat(courseplay.DBG_COURSE_GENERATOR, '%s: ref to attacher joint %.1f, att to implement root %.1f, impl root to ref %.1f',
+        courseplay.debugFormat(courseplay.DBG_PATHFINDER, '%s: ref to attacher joint %.1f, att to implement root %.1f, impl root to ref %.1f',
             nameNum(implement.object), referenceToAttacherJoint, attacherJointToImplementRoot, rootToReferenceNodeOffset)
     else
         _, _, rootToReferenceNodeOffset = localToLocal(implement.object.rootNode, referenceNode, 0, 0, 0)
@@ -142,7 +142,7 @@ function PathfinderUtil.VehicleData:calculateSizeOfObjectList(vehicle, implement
             self.dRight = math.min(self.dRight, rectangle.dRight)
         end
     end
-    --courseplay.debugVehicle(courseplay.DBG_COURSE_GENERATOR, vehicle, 'Size: dFront %.1f, dRear %.1f, dLeft = %.1f, dRight = %.1f',
+    --courseplay.debugVehicle(courseplay.DBG_PATHFINDER, vehicle, 'Size: dFront %.1f, dRear %.1f, dLeft = %.1f, dRight = %.1f',
     --        self.dFront, self.dRear, self.dLeft, self.dRight)
 end
 
@@ -242,10 +242,10 @@ function PathfinderUtil.setUpVehicleCollisionData(myVehicle, vehiclesToIgnore)
         local ignore = PathfinderUtil.elementOf(vehiclesToIgnore, vehicle) or
                 (otherRootVehicle and PathfinderUtil.elementOf(vehiclesToIgnore, otherRootVehicle))
         if ignore then
-            courseplay.debugVehicle(courseplay.DBG_14, myVehicle, 'ignoring %s for collisions during pathfinding', vehicle:getName())
+            courseplay.debugVehicle(courseplay.DBG_PATHFINDER, myVehicle, 'ignoring %s for collisions during pathfinding', vehicle:getName())
         elseif vehicle:getRootVehicle() ~= myRootVehicle and vehicle.rootNode and vehicle.sizeWidth and vehicle.sizeLength then
             local x, _, z = getWorldTranslation(vehicle.rootNode)
-            courseplay.debugVehicle(courseplay.DBG_14, myVehicle, 'othervehicle %s at %.1f %.1f, otherroot %s, myroot %s',
+            courseplay.debugVehicle(courseplay.DBG_PATHFINDER, myVehicle, 'othervehicle %s at %.1f %.1f, otherroot %s, myroot %s',
                     vehicle:getName(), x, z, vehicle:getRootVehicle():getName(), myRootVehicle:getName())
             table.insert(vehicleCollisionData, PathfinderUtil.getBoundingBoxInWorldCoordinates(vehicle.rootNode, PathfinderUtil.VehicleData(vehicle)))
         end
@@ -259,7 +259,7 @@ function PathfinderUtil.findCollidingVehicles(myCollisionData, node, myVehicleDa
         -- check for collision with the vehicle's bounding box
         if PathfinderUtil.doRectanglesOverlap(myCollisionData.corners, collisionData.corners) then
             if log then
-                courseplay.debugFormat(courseplay.DBG_COURSE_GENERATOR, 'pathfinder colliding vehicle x = %.1f, z = %.1f, %s', myCollisionData.center.x, myCollisionData.center.z, collisionData.name)
+                courseplay.debugFormat(courseplay.DBG_PATHFINDER, 'pathfinder colliding vehicle x = %.1f, z = %.1f, %s', myCollisionData.center.x, myCollisionData.center.z, collisionData.name)
             end
             -- check for collision of the individual parts
             for _, rectangle in ipairs(myVehicleData.rectangles) do
@@ -290,7 +290,7 @@ function PathfinderUtil.CollisionDetector:overlapBoxCallback(transformId)
             -- just bumped into myself or a vehicle we want to ignore
             return
         end
-        --courseplay.debugFormat(courseplay.DBG_COURSE_GENERATOR, 'collision: %s', collidingObject:getName())
+        --courseplay.debugFormat(courseplay.DBG_PATHFINDER, 'collision: %s', collidingObject:getName())
     end
    if not getHasClassId(transformId, ClassIds.TERRAIN_TRANSFORM_GROUP) then
         --[[
@@ -300,7 +300,7 @@ function PathfinderUtil.CollisionDetector:overlapBoxCallback(transformId)
                 text = text .. ' ' .. key
             end
         end
-        courseplay.debugFormat(courseplay.DBG_COURSE_GENERATOR, 'collision %d, %s', transformId, text)
+        courseplay.debugFormat(courseplay.DBG_PATHFINDER, 'collision %d, %s', transformId, text)
         -- ignore collision with terrain (may happen on slopes)
         ]]--
         self.collidingShapes = self.collidingShapes + 1
@@ -327,7 +327,7 @@ function PathfinderUtil.CollisionDetector:findCollidingShapes(node, vehicleData,
     if log and self.collidingShapes > 0 then
         table.insert(PathfinderUtil.overlapBoxes,
                 { x = x, y = y + 0.2, z = z, yRot = yRot, width = width, length = length})
-        courseplay.debugFormat(courseplay.DBG_COURSE_GENERATOR, 'pathfinder colliding shapes (%s) at x = %.1f, z = %.1f, (%.1fx%.1f), yRot = %d',
+        courseplay.debugFormat(courseplay.DBG_PATHFINDER, 'pathfinder colliding shapes (%s) at x = %.1f, z = %.1f, (%.1fx%.1f), yRot = %d',
                 vehicleData.name, x, z, width, length, math.deg(yRot))
     end
     DebugUtil.drawOverlapBox(x, y, z, 0, yRot, 0, width, 1, length, 100, 0, 0)
@@ -351,7 +351,7 @@ function PathfinderUtil.hasFruit(x, z, length, width)
             -- if the last boolean parameter is true then it returns fruitValue > 0 for fruits/states ready for forage also
             local fruitValue, a, b, c = FSDensityMapUtil.getFruitArea(fruitType.index, x - width / 2, z - length / 2, x + width / 2, z, x, z + length / 2, true, true)
             --if g_updateLoopIndex % 200 == 0 then
-                --courseplay.debugFormat(courseplay.DBG_COURSE_GENERATOR, '%.1f, %s, %s, %s %s', fruitValue, tostring(a), tostring(b), tostring(c), g_fruitTypeManager:getFruitTypeByIndex(fruitType.index).name)
+                --courseplay.debugFormat(courseplay.DBG_PATHFINDER, '%.1f, %s, %s, %s %s', fruitValue, tostring(a), tostring(b), tostring(c), g_fruitTypeManager:getFruitTypeByIndex(fruitType.index).name)
             --end
             if fruitValue > 0 then
                 return true, fruitValue, g_fruitTypeManager:getFruitTypeByIndex(fruitType.index).name
@@ -465,7 +465,7 @@ function PathfinderConstraints:init(context, maxFruitPercent, offFieldPenalty, f
     self.initialMaxFruitPercent = self.maxFruitPercent
     self.initialOffFieldPenalty = self.offFieldPenalty
     self:resetCounts()
-    courseplay.debugFormat(courseplay.DBG_COURSE_GENERATOR, 'Pathfinder constraints: off field penalty %.1f, max fruit percent: %d, field number %d',
+    courseplay.debugFormat(courseplay.DBG_PATHFINDER, 'Pathfinder constraints: off field penalty %.1f, max fruit percent: %d, field number %d',
         self.offFieldPenalty, self.maxFruitPercent, self.fieldNum)
 end
 
@@ -527,7 +527,7 @@ function PathfinderConstraints:isValidAnalyticSolutionNode(node, log)
     local analyticLimit = self.maxFruitPercent * 2
     if hasFruit and fruitValue > analyticLimit then
         if log then
-            courseplay.debugFormat(courseplay.DBG_COURSE_GENERATOR, 'isValidAnalyticSolutionNode: fruitValue %.1f, max %.1f @ %.1f, %.1f',
+            courseplay.debugFormat(courseplay.DBG_PATHFINDER, 'isValidAnalyticSolutionNode: fruitValue %.1f, max %.1f @ %.1f, %.1f',
                     fruitValue, analyticLimit, node.x, -node.y)
         end
         return false
@@ -577,20 +577,20 @@ end
 
 function PathfinderConstraints:relaxConstraints()
     self:showStatistics()
-    courseplay.debugFormat(courseplay.DBG_COURSE_GENERATOR, 'relaxing pathfinder constraints: allow driving through fruit')
+    courseplay.debugFormat(courseplay.DBG_PATHFINDER, 'relaxing pathfinder constraints: allow driving through fruit')
     self.maxFruitPercent = math.huge
     self:resetCounts()
 end
 
 function PathfinderConstraints:showStatistics()
-    courseplay.debugFormat(courseplay.DBG_COURSE_GENERATOR, 'Nodes: %d, Penalties: fruit: %d, off-field: %d, collisions: %d',
+    courseplay.debugFormat(courseplay.DBG_PATHFINDER, 'Nodes: %d, Penalties: fruit: %d, off-field: %d, collisions: %d',
             self.totalNodeCount, self.fruitPenaltyNodeCount, self.offFieldPenaltyNodeCount, self.collisionNodeCount)
-    courseplay.debugFormat(courseplay.DBG_COURSE_GENERATOR, '  max fruit %.1f %%, off-field penalty: %.1f',
+    courseplay.debugFormat(courseplay.DBG_PATHFINDER, '  max fruit %.1f %%, off-field penalty: %.1f',
             self.maxFruitPercent, self.offFieldPenalty)
 end
 
 function PathfinderConstraints:resetConstraints()
-    courseplay.debugFormat(courseplay.DBG_COURSE_GENERATOR, 'resetting pathfinder constraints: maximum fruit percent allowed is now %d',
+    courseplay.debugFormat(courseplay.DBG_PATHFINDER, 'resetting pathfinder constraints: maximum fruit percent allowed is now %d',
             self.initialMaxFruitPercent)
     self.maxFruitPercent = self.initialMaxFruitPercent
     self:resetCounts()

--- a/course-generator/courseGenerator.lua
+++ b/course-generator/courseGenerator.lua
@@ -82,7 +82,7 @@ end
 --  or use the CP debug channel when running in the game.
 function courseGenerator.debug( ... )
 	if courseGenerator.isRunningInGame() then
-		courseplay:debug( string.format( ... ), courseplay.DBG_COURSE_GENERATOR )
+		courseplay:debug( string.format( ... ), courseplay.DBG_COURSES )
 	else
 		print( string.format( ... ))
 		io.stdout:flush()

--- a/course-generator/cp.lua
+++ b/course-generator/cp.lua
@@ -56,7 +56,7 @@ function courseGenerator.generate( vehicle )
 	if vehicle.cp.fieldEdge.selectedField.fieldNum > 0 then
 		fieldCourseName = courseplay.fields.fieldData[vehicle.cp.fieldEdge.selectedField.fieldNum].name;
 	end;
-	courseplay:debug(string.format("generateCourse() called for %q", fieldCourseName), courseplay.DBG_COURSE_GENERATOR);
+	courseplay:debug(string.format("generateCourse() called for %q", fieldCourseName), courseplay.DBG_COURSES);
 
 	local poly = {}
 	local islandNodes = {}
@@ -96,19 +96,19 @@ function courseGenerator.generate( vehicle )
 
 	if vehicle.cp.startingCorner == courseGenerator.STARTING_LOCATION_LAST_VEHICLE_POSITION and vehicle.cp.generationPosition.hasSavedPosition then
 		headlandSettings.startLocation = courseGenerator.pointToXy({ x = vehicle.cp.generationPosition.x, z = vehicle.cp.generationPosition.z })
-		courseplay.debugVehicle(courseplay.DBG_COURSE_GENERATOR, vehicle, "Course starting location is last vehicle position at %.1f/%.1f",
+		courseplay.debugVehicle(courseplay.DBG_COURSES, vehicle, "Course starting location is last vehicle position at %.1f/%.1f",
 			vehicle.cp.generationPosition.x, vehicle.cp.generationPosition.z )
 	elseif courseGenerator.isOrdinalDirection( vehicle.cp.startingCorner ) then
 		headlandSettings.startLocation = courseGenerator.getStartingLocation( field.boundary, vehicle.cp.startingCorner )
-		courseplay.debugVehicle(courseplay.DBG_COURSE_GENERATOR, vehicle, "Course starting location is corner %d", vehicle.cp.startingCorner )
+		courseplay.debugVehicle(courseplay.DBG_COURSES, vehicle, "Course starting location is corner %d", vehicle.cp.startingCorner )
 	elseif vehicle.cp.startingCorner == courseGenerator.STARTING_LOCATION_VEHICLE_POSITION then
 		local x, z
 		x, _, z = getWorldTranslation( vehicle.rootNode )
 		headlandSettings.startLocation = courseGenerator.pointToXy({ x = x, z = z })
-		courseplay.debugVehicle(courseplay.DBG_COURSE_GENERATOR, vehicle, "Course starting location is current vehicle position at %.1f/%.1f", x, z )
+		courseplay.debugVehicle(courseplay.DBG_COURSES, vehicle, "Course starting location is current vehicle position at %.1f/%.1f", x, z )
 	elseif vehicle.cp.oldCourseGeneratorSettings.startingLocationWorldPos then
 		headlandSettings.startLocation = courseGenerator.pointToXy(vehicle.cp.oldCourseGeneratorSettings.startingLocationWorldPos)
-		courseplay.debugVehicle(courseplay.DBG_COURSE_GENERATOR, vehicle, "Course starting location position selected on map at %.1f/%.1f",
+		courseplay.debugVehicle(courseplay.DBG_COURSES, vehicle, "Course starting location position selected on map at %.1f/%.1f",
 			vehicle.cp.oldCourseGeneratorSettings.startingLocationWorldPos.x,
 			vehicle.cp.oldCourseGeneratorSettings.startingLocationWorldPos.z)
 	end
@@ -191,7 +191,7 @@ function courseGenerator.generate( vehicle )
 	vehicle.cp.numWaypoints = #vehicle.Waypoints
 
 	if vehicle.cp.numWaypoints == 0 then
-		courseplay:debug('ERROR: #vehicle.Waypoints == 0 -> cancel and return', courseplay.DBG_COURSE_GENERATOR);
+		courseplay:debug('ERROR: #vehicle.Waypoints == 0 -> cancel and return', courseplay.DBG_COURSES);
 		return status, ok;
 	end;
 

--- a/course_management.lua
+++ b/course_management.lua
@@ -5,7 +5,7 @@ local ceil = math.ceil;
 function courseplay.courses:setup()
 	-- LOAD COURSES AND FOLDERS FROM XML
 	if g_currentMission.cp_courses == nil then
-		-- courseplay:debug("cp_courses was nil and initialized", courseplay.DBG_COURSE_MANAGEMENT);
+		-- courseplay:debug("cp_courses was nil and initialized", courseplay.DBG_COURSES);
 		g_currentMission.cp_courses = {};
 		g_currentMission.cp_courseManager = {};
 		g_currentMission.cp_folders = {};
@@ -13,7 +13,7 @@ function courseplay.courses:setup()
 
 		if g_server ~= nil and next(g_currentMission.cp_courses) == nil then
 			self:loadCoursesAndFoldersFromXml();
-			-- courseplay:debug(tableShow(g_currentMission.cp_courses, "g_cM cp_courses", 8), courseplay.DBG_COURSE_MANAGEMENT);
+			-- courseplay:debug(tableShow(g_currentMission.cp_courses, "g_cM cp_courses", 8), courseplay.DBG_COURSES);
 		end;
 	end;
 end;
@@ -64,7 +64,7 @@ function courseplay:showSaveCourseForm(vehicle, saveWhat) -- fn is in courseplay
 end;
 
 function courseplay:reloadCourses(vehicle, useRealId) -- fn is in courseplay because it's vehicle based
-	courseplay:debug(('%s: reloadCourses(..., %s)'):format(nameNum(vehicle), tostring(useRealId)), courseplay.DBG_COURSE_MANAGEMENT);
+	courseplay:debug(('%s: reloadCourses(..., %s)'):format(nameNum(vehicle), tostring(useRealId)), courseplay.DBG_COURSES);
 	local courses = vehicle.cp.loadedCourses;
 	vehicle.cp.loadedCourses = {};
 	for k, v in pairs(courses) do
@@ -74,7 +74,7 @@ end;
 
 function courseplay.courses:reinitializeCourses()
 	if g_currentMission.cp_courses == nil then
-		courseplay:debug("cp_courses is empty", courseplay.DBG_COURSE_MANAGEMENT)
+		courseplay:debug("cp_courses is empty", courseplay.DBG_COURSES)
 		if g_server ~= nil then
 			self:loadCoursesAndFoldersFromXml();
 		end
@@ -100,7 +100,7 @@ function courseplay:loadCourse(vehicle, id, useRealId, addCourseAtEnd) -- fn is 
 	
 	if addCourseAtEnd == nil then addCourseAtEnd = false; end;
 
-	courseplay:debug(string.format('%s: loadCourse(..., id=%s, useRealId=%s, addCourseAtEnd=%s)', nameNum(vehicle), tostring(id), tostring(useRealId), tostring(addCourseAtEnd)), courseplay.DBG_COURSE_MANAGEMENT);
+	courseplay:debug(string.format('%s: loadCourse(..., id=%s, useRealId=%s, addCourseAtEnd=%s)', nameNum(vehicle), tostring(id), tostring(useRealId), tostring(addCourseAtEnd)), courseplay.DBG_COURSES);
 	if id ~= nil and id ~= "" then
 		if not useRealId then
 			-- this useRealId smells to heaven...
@@ -121,7 +121,7 @@ function courseplay:loadCourse(vehicle, id, useRealId, addCourseAtEnd) -- fn is 
 
 		if not g_currentMission.cp_courses[id].waypoints and not g_currentMission.cp_courses[id].virtual then
 			if not CpManager.isMP or not courseplay.isClient then
-				courseplay.debugVehicle(courseplay.DBG_COURSE_MANAGEMENT, vehicle, 'Loading course %d (%s)', id, g_currentMission.cp_courses[id].nameClean)
+				courseplay.debugVehicle(courseplay.DBG_COURSES, vehicle, 'Loading course %d (%s)', id, g_currentMission.cp_courses[id].nameClean)
 				courseplay.courses:loadCourseFromFile(g_currentMission.cp_courses[id])
 			else
 				g_currentMission.cp_courses[id].waypoints = {}
@@ -165,7 +165,7 @@ function courseplay:loadCourse(vehicle, id, useRealId, addCourseAtEnd) -- fn is 
 
 			courseplay:debug(string.format("course_management %d: %s: no course was loaded -> new course = course -> currentCourseName=%q, numCourses=%s",
 				debug.getinfo(1).currentline, nameNum(vehicle), tostring(vehicle.cp.currentCourseName),
-				tostring(vehicle.cp.numCourses)), courseplay.DBG_COURSE_MANAGEMENT);
+				tostring(vehicle.cp.numCourses)), courseplay.DBG_COURSES);
 
 		else -- add new course to old course
 			if vehicle.cp.currentCourseName == nil then --recorded but not saved course
@@ -173,7 +173,7 @@ function courseplay:loadCourse(vehicle, id, useRealId, addCourseAtEnd) -- fn is 
 			end;
 			courseplay:debug(string.format("course_management %d: %s: currentCourseName=%q, numCourses=%s -> add new course %q",
 				debug.getinfo(1).currentline, nameNum(vehicle), tostring(vehicle.cp.currentCourseName),
-				tostring(vehicle.cp.numCourses), tostring(course.name)), courseplay.DBG_COURSE_MANAGEMENT);
+				tostring(vehicle.cp.numCourses), tostring(course.name)), courseplay.DBG_COURSES);
 
 
 			local course1, course2 = vehicle.Waypoints, course.waypoints;
@@ -190,17 +190,17 @@ function courseplay:loadCourse(vehicle, id, useRealId, addCourseAtEnd) -- fn is 
 				local crossingPoints = { [1] = {}, [2] = {} };
 				for i=vehicle.cp.lastMergedWP + 1, numCourse1 do
 					if i > 1 and course1[i].crossing == true and not course1[i].merged then
-						courseplay:debug('course1 wp ' .. i .. ': add to crossingPoints[1]', courseplay.DBG_COURSE_MANAGEMENT);
+						courseplay:debug('course1 wp ' .. i .. ': add to crossingPoints[1]', courseplay.DBG_COURSES);
 						table.insert(crossingPoints[1], i);
 					end;
 				end;
 				for i,wp in pairs(course2) do
 					if i < numCourse2 and wp.crossing == true and not wp.merged then
-						courseplay:debug('course2 wp ' .. i .. ': add to crossingPoints[2]', courseplay.DBG_COURSE_MANAGEMENT);
+						courseplay:debug('course2 wp ' .. i .. ': add to crossingPoints[2]', courseplay.DBG_COURSES);
 						table.insert(crossingPoints[2], i);
 					end;
 				end;
-				courseplay:debug(string.format('course 1 has %d crossing points (excluding first point), course 2 has %d crossing points (excluding last point), useFirstMatch=%s', #crossingPoints[1], #crossingPoints[2], tostring(useFirstMatch)), courseplay.DBG_COURSE_MANAGEMENT);
+				courseplay:debug(string.format('course 1 has %d crossing points (excluding first point), course 2 has %d crossing points (excluding last point), useFirstMatch=%s', #crossingPoints[1], #crossingPoints[2], tostring(useFirstMatch)), courseplay.DBG_COURSES);
 
 				--find < wpDistMax match with lowest total turn angle
 				local smallestAngle, smallestDist = math.huge, math.huge;
@@ -218,7 +218,7 @@ function courseplay:loadCourse(vehicle, id, useRealId, addCourseAtEnd) -- fn is 
 								math.abs(getDeltaAngle(math.rad(wp1.angle),angleTurn)) +
 									math.abs(getDeltaAngle(angleTurn,math.rad(wp2.angle))))
 							angleTurn = math.deg(angleTurn) -- now in degrees
-							--courseplay:debug(string.format('course1 wp %d, course2 wp %d, dist=%s', wpNum1, wpNum2, tostring(dist)), courseplay.DBG_COURSE_MANAGEMENT);
+							--courseplay:debug(string.format('course1 wp %d, course2 wp %d, dist=%s', wpNum1, wpNum2, tostring(dist)), courseplay.DBG_COURSES);
 							if dist and dist ~= 0 and dist < wpDistMax then
 								courseplay:debug(string.format('wp1 %d %.2f° wp2 %d %.2f° dist=%.1f angleTurn %.2f°, totalAngle %.2f°, lowA %.2f°, lowD %.1f',
 									wpNum1, wp1.angle, wpNum2, wp2.angle, dist, angleTurn , totalAngle, smallestAngle, smallestDist), 8);
@@ -250,7 +250,7 @@ function courseplay:loadCourse(vehicle, id, useRealId, addCourseAtEnd) -- fn is 
 									vehicle.cp.lastMergedWP = wpNum1;
 									course1[course1wp].merged = true;
 									course2[course2wp].merged = true;
-									courseplay.debugVehicle(courseplay.DBG_COURSE_MANAGEMENT, vehicle,
+									courseplay.debugVehicle(courseplay.DBG_COURSES, vehicle,
 										'wp1 %d %.2f° wp2 %d %.2f° dist=%.1f angleTurn %.2f°, totalAngle %.2f°, lowA %.2f°, lowD %.1f',
 										wpNum1, wp1.angle, wpNum2, wp2.angle, dist, angleTurn , totalAngle, smallestAngle, smallestDist)
 								end;
@@ -295,7 +295,7 @@ function courseplay:loadCourse(vehicle, id, useRealId, addCourseAtEnd) -- fn is 
 			end;
 
 
-			courseplay:debug(string.format('%s: adding course done -> numWaypoints=%d, numCourses=%s, currentCourseName=%q', nameNum(vehicle), vehicle.cp.numWaypoints, vehicle.cp.numCourses, vehicle.cp.currentCourseName), courseplay.DBG_COURSE_MANAGEMENT);
+			courseplay:debug(string.format('%s: adding course done -> numWaypoints=%d, numCourses=%s, currentCourseName=%q', nameNum(vehicle), vehicle.cp.numWaypoints, vehicle.cp.numCourses, vehicle.cp.currentCourseName), courseplay.DBG_COURSES);
 		end;
 
 
@@ -1334,12 +1334,12 @@ function courseplay.courses:reloadVehicleCourses(vehicle)
 			local parent
 			local courses, folders = {}, {}
 			local searchTermClean = courseplay:normalizeUTF8(vehicle.cp.hud.filter);
-			courseplay:debug(string.format("%s: [filter] searchTermClean = %q", nameNum(vehicle), tostring(searchTermClean)), courseplay.DBG_COURSE_MANAGEMENT);
+			courseplay:debug(string.format("%s: [filter] searchTermClean = %q", nameNum(vehicle), tostring(searchTermClean)), courseplay.DBG_COURSES);
 
 			-- filter courses
 			for k, course in pairs(g_currentMission.cp_courses) do
 				if string.match(course.nameClean, searchTermClean) ~= nil then
-					courseplay:debug(string.format("\tmatch: course.nameClean=%q / searchTermClean = %q", tostring(course.nameClean), tostring(searchTermClean)), courseplay.DBG_COURSE_MANAGEMENT);
+					courseplay:debug(string.format("\tmatch: course.nameClean=%q / searchTermClean = %q", tostring(course.nameClean), tostring(searchTermClean)), courseplay.DBG_COURSES);
 					courses[k] = course
 					-- add parents
 					parent = course.parent
@@ -1359,7 +1359,7 @@ function courseplay.courses:reloadVehicleCourses(vehicle)
 		
 		-- update items for the hud
 		courseplay.hud.reloadCourses(vehicle);
-		courseplay.debugVehicle(courseplay.DBG_COURSE_MANAGEMENT, vehicle, 'reloadVehicleCourses')
+		courseplay.debugVehicle(courseplay.DBG_COURSES, vehicle, 'reloadVehicleCourses')
 		vehicle.cp.reloadCourseItems = false
 	end -- end vehicle ~= nil
 end
@@ -1528,7 +1528,7 @@ function courseplay.courses:loadCoursesAndFoldersFromXml()
 
 		g_currentMission.cp_sorted = self:sort(courses_by_id, folders_by_id, 0, 0)
 
-		--courseplay:debug(tableShow(g_currentMission.cp_sorted.item, "cp_sorted.item", 8), courseplay.DBG_COURSE_MANAGEMENT);
+		--courseplay:debug(tableShow(g_currentMission.cp_sorted.item, "cp_sorted.item", 8), courseplay.DBG_COURSES);
 
 		return g_currentMission.cp_courses;
 	elseif CpManager.cpCourseManagerXmlFilePath then
@@ -1552,7 +1552,7 @@ function courseplay:getAllowedCharacters()
 	for unicode=allowedSpan.from,allowedSpan.to do
 		prohibitedUnicodes[unicode] = prohibitedUnicodes[unicode] or false;
 		result[unicode] = not prohibitedUnicodes[unicode] and getCanRenderUnicode(unicode);
-		if courseplay.debugChannels and courseplay.debugChannels[courseplay.DBG_COURSE_MANAGEMENT] and getCanRenderUnicode(unicode) then
+		if courseplay.debugChannels and courseplay.debugChannels[courseplay.DBG_COURSES] and getCanRenderUnicode(unicode) then
 			print(string.format('allowedCharacters[%d]=%s (%q) (prohibited=%s, getCanRenderUnicode()=true)', unicode, tostring(result[unicode]), unicodeToUtf8(unicode), tostring(prohibitedUnicodes[unicode])));
 		end;
 	end;
@@ -1622,18 +1622,18 @@ end;
 function courseplay:normalizeUTF8(str)
 	local len = str:len();
 	local utfLen = utf8Strlen(str);
-	courseplay:debug(string.format("str %q: len=%d, utfLen=%d", str, len, utfLen), courseplay.DBG_COURSE_MANAGEMENT);
+	courseplay:debug(string.format("str %q: len=%d, utfLen=%d", str, len, utfLen), courseplay.DBG_COURSES);
 
 	if len ~= utfLen then --special char in str
 		local result = "";
 		for i=0,utfLen-1 do
 			local char = utf8Substr(str,i,1);
-			courseplay:debug(string.format("\tchar=%q, replaceChar=%q", char, tostring(courseplay.utf8normalization[char])), courseplay.DBG_COURSE_MANAGEMENT);
+			courseplay:debug(string.format("\tchar=%q, replaceChar=%q", char, tostring(courseplay.utf8normalization[char])), courseplay.DBG_COURSES);
 
 			local clean = courseplay.utf8normalization[char] or char:lower();
 			result = result .. clean;
 		end;
-		courseplay:debug(string.format("normalizeUTF8(%q) --> clean=%q", str, result), courseplay.DBG_COURSE_MANAGEMENT);
+		courseplay:debug(string.format("normalizeUTF8(%q) --> clean=%q", str, result), courseplay.DBG_COURSES);
 		return result;
 	end;
 
@@ -1874,7 +1874,7 @@ function courseplay.courses:loadAutoDriveCourse(vehicle, course)
 		adCourse = vehicle.spec_autodrive:GetPath(x, z, yRot, course.adDestinationId, options)
 	end
 	if adCourse then
-		courseplay.debugVehicle(courseplay.DBG_COURSE_MANAGEMENT, vehicle, 'Received AD course with %d waypoints', #adCourse)
+		courseplay.debugVehicle(courseplay.DBG_COURSES, vehicle, 'Received AD course with %d waypoints', #adCourse)
 	else
 		courseplay.infoVehicle(vehicle, 'AutoDrive could not give us a course from the current position to %s', course.adDestinationName)
 		return nil

--- a/courseplay_event.lua
+++ b/courseplay_event.lua
@@ -259,7 +259,7 @@ function CourseplayJoinFixEvent:readStream(streamId, connection)
 		print(string.format("\t### CourseplayMultiplayer: reading %d couses ", course_count ))
 		g_currentMission.cp_courses = {}
 		for i = 1, course_count do
-			--courseplay:debug("got course", courseplay.DBG_COURSE_MANAGEMENT);
+			--courseplay:debug("got course", courseplay.DBG_COURSES);
 			local course_name = streamDebugReadString(streamId)
 			local courseUid = streamDebugReadString(streamId)
 			local courseType = streamDebugReadString(streamId)
@@ -270,7 +270,7 @@ function CourseplayJoinFixEvent:readStream(streamId, connection)
 			local waypoints = {}
 			if wp_count >= 0 then
 				for w = 1, wp_count do
-					--courseplay:debug("got waypoint", courseplay.DBG_COURSE_MANAGEMENT);
+					--courseplay:debug("got waypoint", courseplay.DBG_COURSES);
 					table.insert(waypoints, CourseEvent:readWaypoint(streamId))
 				end
 			else
@@ -326,7 +326,7 @@ function CourseplayJoinFixEvent:readStream(streamId, connection)
 end
 
 function CourseplayJoinFixEvent:run(connection)
-	--courseplay:debug("CourseplayJoinFixEvent Run function should never be called", courseplay.DBG_COURSE_MANAGEMENT);
+	--courseplay:debug("CourseplayJoinFixEvent Run function should never be called", courseplay.DBG_COURSES);
 end;
 
 ---------------------------------

--- a/debug.lua
+++ b/debug.lua
@@ -1,4 +1,6 @@
 courseplay = courseplay or {}
+
+-- Debug channels. The numbers represent the channel numbers on the HUD
 courseplay.DBG_TRIGGERS = 1
 courseplay.DBG_LOAD_UNLOAD = 2
 courseplay.DBG_TRAFFIC = 3

--- a/debug.lua
+++ b/debug.lua
@@ -50,7 +50,6 @@ function CpManager:setUpDebugChannels()
 			defaultActive[courseplay.DBG_TURN] = true;
 			defaultActive[courseplay.DBG_IMPLEMENTS] = true;
 			defaultActive[courseplay.DBG_COURSES] = true;
-			defaultActive[courseplay.DBG_COURSES] = true;
 			defaultActive[courseplay.DBG_PATHFINDER] = true;
 			defaultActive[courseplay.DBG_MODE_4] = true;
 			defaultActive[courseplay.DBG_TRAFFIC] = true;
@@ -94,7 +93,7 @@ function CpManager:setUpDebugChannels()
 		[courseplay.DBG_REVERSE] = 'Debug: reverse driving';
 		[courseplay.DBG_TURN] = 'Debug: driving specific';
 		[courseplay.DBG_PPC] = 'Debug: pure pursuit controller';
-		[courseplay.DBG_LOAD_UNLOAD] = 'Debug: Load and unload tippers';
+		[courseplay.DBG_LOAD_UNLOAD] = 'Debug: load and unload tippers';
 		[courseplay.DBG_TRAFFIC] = 'Debug: traffic collision/proximity';
 		[courseplay.DBG_HUD] = 'Debug: hud action';
 		[courseplay.DBG_COURSES] = 'Debug: course save/load/generation';

--- a/debug.lua
+++ b/debug.lua
@@ -91,7 +91,7 @@ function CpManager:setUpDebugChannels()
 		[courseplay.DBG_PATHFINDER] = 'Debug: pathfinder';
 		[courseplay.DBG_TRIGGERS] = 'Debug: triggers';
 		[courseplay.DBG_REVERSE] = 'Debug: reverse driving';
-		[courseplay.DBG_TURN] = 'Debug: driving specific';
+		[courseplay.DBG_TURN] = 'Debug: turns';
 		[courseplay.DBG_PPC] = 'Debug: pure pursuit controller';
 		[courseplay.DBG_LOAD_UNLOAD] = 'Debug: load and unload tippers';
 		[courseplay.DBG_TRAFFIC] = 'Debug: traffic collision/proximity';

--- a/debug.lua
+++ b/debug.lua
@@ -1,29 +1,29 @@
 courseplay = courseplay or {}
 
 -- Debug channels. The numbers represent the channel numbers on the HUD
-courseplay.DBG_TRIGGERS = 1
-courseplay.DBG_LOAD_UNLOAD = 2
-courseplay.DBG_TRAFFIC = 3
-courseplay.DBG_MODE_2_3 = 4
-courseplay.DBG_MULTIPLAYER = 5
-courseplay.DBG_IMPLEMENTS = 6
-courseplay.DBG_COURSE_GENERATOR = 7
-courseplay.DBG_COURSE_MANAGEMENT = 8
-courseplay.DBG_PATHFINDING = 9
-courseplay.DBG_10 = 10
-courseplay.DBG_11 = 11
-courseplay.DBG_12 = 12
-courseplay.DBG_13 = 13
-courseplay.DBG_14 = 14
-courseplay.DBG_15 = 15
-courseplay.DBG_16 = 16
-courseplay.DBG_17 = 17
-courseplay.DBG_18 = 18
-courseplay.DBG_19 = 19
-courseplay.DBG_20 = 20
-courseplay.DBG_21 = 21
-courseplay.DBG_22 = 22
-courseplay.DBG_23 = 23
+courseplay.DBG_MODE_1 = 1
+courseplay.DBG_MODE_2 = 2
+courseplay.DBG_MODE_3 = 3
+courseplay.DBG_MODE_4 = 4
+courseplay.DBG_MODE_5 = 5
+courseplay.DBG_MODE_6 = 6
+courseplay.DBG_MODE_7 = 7
+courseplay.DBG_MODE_8 = 8
+courseplay.DBG_MODE_9 = 9
+courseplay.DBG_MODE_10 = 10
+courseplay.DBG_PATHFINDER = 11
+courseplay.DBG_TRIGGERS = 12
+courseplay.DBG_REVERSE = 13
+courseplay.DBG_TURN = 14
+courseplay.DBG_PPC = 15
+courseplay.DBG_LOAD_UNLOAD = 16
+courseplay.DBG_TRAFFIC = 17
+courseplay.DBG_HUD = 18
+courseplay.DBG_COURSES = 19
+courseplay.DBG_MULTIPLAYER = 20
+courseplay.DBG_IMPLEMENTS = 21
+courseplay.DBG_UNCATEGORIZED = 22
+courseplay.DBG_AI_DRIVER = 23
 courseplay.DBG_CYCLIC = 24
 
 function CpManager:setUpDebugChannels()
@@ -35,24 +35,24 @@ function CpManager:setUpDebugChannels()
 		-- Enable specified debugmode by default for Satis Only!
 		if getMD5(g_gameSettings:getValue("nickname")) == "9a9f028043394ff9de1cf6c905b515c1" then
 			defaultActive[courseplay.DBG_IMPLEMENTS] = true;
-			defaultActive[courseplay.DBG_12] = true;
-			defaultActive[courseplay.DBG_13] = true;
-			defaultActive[courseplay.DBG_14] = true;
+			defaultActive[courseplay.DBG_PPC] = true;
+			defaultActive[courseplay.DBG_REVERSE] = true;
+			defaultActive[courseplay.DBG_TURN] = true;
 		end;
 		if getMD5(g_gameSettings:getValue("nickname")) == "b74ad095badc54d4334039f2f73f240e" then
 			defaultActive[courseplay.DBG_IMPLEMENTS] = true;
-			defaultActive[courseplay.DBG_13] = true;
+			defaultActive[courseplay.DBG_REVERSE] = true;
 		end;
 		if getMD5(g_gameSettings:getValue("nickname")) == "3e701b6620453edcd4c170543e72788b" then
-			defaultActive[courseplay.DBG_11] = true;
-			defaultActive[courseplay.DBG_12] = true;
-			defaultActive[courseplay.DBG_13] = true;
-			defaultActive[courseplay.DBG_14] = true;
+			defaultActive[courseplay.DBG_AI_DRIVER] = true;
+			defaultActive[courseplay.DBG_PPC] = true;
+			defaultActive[courseplay.DBG_REVERSE] = true;
+			defaultActive[courseplay.DBG_TURN] = true;
 			defaultActive[courseplay.DBG_IMPLEMENTS] = true;
-			defaultActive[courseplay.DBG_COURSE_GENERATOR] = true;
-			defaultActive[courseplay.DBG_COURSE_MANAGEMENT] = true;
-			defaultActive[courseplay.DBG_PATHFINDING] = true;
-			defaultActive[courseplay.DBG_MODE_2_3] = true;
+			defaultActive[courseplay.DBG_COURSES] = true;
+			defaultActive[courseplay.DBG_COURSES] = true;
+			defaultActive[courseplay.DBG_PATHFINDER] = true;
+			defaultActive[courseplay.DBG_MODE_4] = true;
 			defaultActive[courseplay.DBG_TRAFFIC] = true;
 		end;
 	end;
@@ -79,30 +79,30 @@ function CpManager:setUpDebugChannels()
 	--]]
 	-- Debug channels legend:
 	courseplay.debugChannelsDesc = {
-		[courseplay.DBG_TRIGGERS] = 'Debug: Raycast (drive + tipTriggers)';
+		[courseplay.DBG_MODE_1] = 'Debug: mode 1 - grain transport';
+		[courseplay.DBG_MODE_2] = 'Debug: mode 2 - unload combine';
+		[courseplay.DBG_MODE_3] = 'Debug: mode 3 - overloader';
+		[courseplay.DBG_MODE_4] = 'Debug: mode 4 - fertilizing and seeding';
+		[courseplay.DBG_MODE_5] = 'Debug: mode 5 - transport';
+		[courseplay.DBG_MODE_6] = 'Debug: mode 6 - fieldwork';
+		[courseplay.DBG_MODE_7] = 'Debug: mode 7 - bale collector';
+		[courseplay.DBG_MODE_8] = 'Debug: mode 8 - field supply';
+		[courseplay.DBG_MODE_9] = 'Debug: mode 9 - shovel fill/empty';
+		[courseplay.DBG_MODE_10] = 'Debug: mode 10 - bunker silo compacter';
+		[courseplay.DBG_PATHFINDER] = 'Debug: pathfinder';
+		[courseplay.DBG_TRIGGERS] = 'Debug: triggers';
+		[courseplay.DBG_REVERSE] = 'Debug: reverse driving';
+		[courseplay.DBG_TURN] = 'Debug: driving specific';
+		[courseplay.DBG_PPC] = 'Debug: pure pursuit controller';
 		[courseplay.DBG_LOAD_UNLOAD] = 'Debug: Load and unload tippers';
-		[courseplay.DBG_TRAFFIC] = 'Debug: Traffic collision';
-		[courseplay.DBG_MODE_2_3] = 'Debug: Mode 2/3, combi/overloader';
-		[courseplay.DBG_MULTIPLAYER] = 'Debug: Multiplayer';
-		[courseplay.DBG_IMPLEMENTS] = 'Debug: implements (updateWorkTools etc.)';
-		[courseplay.DBG_COURSE_GENERATOR] = 'Debug: course generation';
-		[courseplay.DBG_COURSE_MANAGEMENT] = 'Debug: course management';
-		[courseplay.DBG_PATHFINDING] = 'Debug: path finding';
-		[courseplay.DBG_10] = 'Debug: mode9: shovel loading/unloading';
-		[courseplay.DBG_11] = 'Debug: AIDriver management';
-		[courseplay.DBG_12] = 'Debug: all other debugs (uncategorized)';
-		[courseplay.DBG_13] = 'Debug: reverse driving';
-		[courseplay.DBG_14] = 'Debug: driving specific';
-		[courseplay.DBG_15] = 'Debug: not used';
-		[courseplay.DBG_16] = 'Debug: recording courses';
-		[courseplay.DBG_17] = 'Debug: mode4/6: seeding/fieldWork';
-		[courseplay.DBG_18] = 'Debug: hud action';
-		[courseplay.DBG_19] = 'Debug: special triggers';
-		[courseplay.DBG_20] = 'Debug: WeightStation';
-		[courseplay.DBG_21] = 'Debug: Speed setting';
-		[courseplay.DBG_22] = 'Debug: temp MP';
-		[courseplay.DBG_23] = 'Debug: mode8: liquid product transport';
-		[courseplay.DBG_CYCLIC] = 'Debug: activate cyclic prints'; --this is to prevent spamming the log if not nessesary (e.g. raycasts)
+		[courseplay.DBG_TRAFFIC] = 'Debug: traffic collision/proximity';
+		[courseplay.DBG_HUD] = 'Debug: hud action';
+		[courseplay.DBG_COURSES] = 'Debug: course save/load/generation';
+		[courseplay.DBG_MULTIPLAYER] = 'Debug: multiplayer';
+		[courseplay.DBG_IMPLEMENTS] = 'Debug: implements';
+		[courseplay.DBG_UNCATEGORIZED] = 'Debug: other';
+		[courseplay.DBG_AI_DRIVER] = 'Debug: AIDriver common';
+		[courseplay.DBG_CYCLIC] = 'Debug: activate cyclic prints'; --this is to prevent spamming the log if not necessary (e.g. raycasts)
 	};
 
 	courseplay.debugButtonPosData = {};
@@ -137,7 +137,7 @@ function courseplay:debug(str, channel)
 end;
 
 -- convenience debug function that expects string.format() arguments,
--- courseplay.debugVehicle( courseplay.DBG_14, "fill level is %.1f, mode = %d", fillLevel, mode )
+-- courseplay.debugVehicle( courseplay.DBG_TURN, "fill level is %.1f, mode = %d", fillLevel, mode )
 ---@param channel number
 function courseplay.debugFormat(channel, ...)
 	if courseplay.debugChannels and channel ~= nil and courseplay.debugChannels[channel] ~= nil and courseplay.debugChannels[channel] == true then
@@ -148,7 +148,7 @@ function courseplay.debugFormat(channel, ...)
 end
 
 -- convenience debug function to show the vehicle name and expects string.format() arguments, 
--- courseplay.debugVehicle( courseplay.DBG_14, vehicle, "fill level is %.1f, mode = %d", fillLevel, mode )
+-- courseplay.debugVehicle( courseplay.DBG_TURN, vehicle, "fill level is %.1f, mode = %d", fillLevel, mode )
 ---@param channel number
 function courseplay.debugVehicle(channel, vehicle, ...)
 	if courseplay.debugChannels and channel ~= nil and courseplay.debugChannels[channel] ~= nil and courseplay.debugChannels[channel] == true then
@@ -500,7 +500,7 @@ end
 -- TODO: there could be a drawTemporaryLine in cpDebug that already has a buffer for all draw data, there's no need to
 -- create a separate one
 function courseplay:showTemporaryMarkers(vehicle)
-	if not courseplay.debugChannels[courseplay.DBG_14] then return end
+	if not courseplay.debugChannels[courseplay.DBG_AI_DRIVER] then return end
 	if vehicle.cp.showMarkers then
 		if vehicle.cp.showMarkers.timer < vehicle.timer then
 			-- time is up, remove markers

--- a/helpers.lua
+++ b/helpers.lua
@@ -25,78 +25,6 @@ function tableConcat(...)
 	return t;
 end;
 
--- TODO: This and isLowered() should be in an AIDriverUtil class or at least in a different file, like toolManager.lua
-function courseplay:isFolding(workTool) --returns isFolding, isFolded, isUnfolded
-	if not courseplay:isFoldable(workTool) then
-		return false, false, true;
-	end;
-
-	local isFolding, isFolded, isUnfolded = false, true, true;
-	courseplay:debug(string.format('%s: isFolding(): realUnfoldDirection=%s, turnOnFoldDirection=%s, startAnimTime=%s, foldMoveDirection=%s', nameNum(workTool), tostring(workTool.cp.realUnfoldDirection), tostring(workTool.turnOnFoldDirection), tostring(workTool.startAnimTime), tostring(workTool.foldMoveDirection)), courseplay.DBG_17);
-	
-	if workTool.spec_foldable.foldAnimTime ~= (workTool.spec_foldable.oldFoldAnimTime or 0) then
-		if workTool.spec_foldable.foldMoveDirection > 0 and workTool.spec_foldable.foldAnimTime < 1 then
-			isFolding = true;
-		elseif workTool.spec_foldable.foldMoveDirection < 0 and workTool.spec_foldable.foldAnimTime > 0 then
-			isFolding = true;
-		end;
-		workTool.spec_foldable.oldFoldAnimTime = workTool.spec_foldable.foldAnimTime;
-	end;
-
-	isUnfolded = workTool:getIsUnfolded();
-	isFolded = not isUnfolded and not isFolding;
-	
-	courseplay:debug(string.format('\treturn isFolding=%s, isFolded=%s, isUnfolded=%s', tostring(isFolding), tostring(isFolded), tostring(isUnfolded)), courseplay.DBG_17);
-	return isFolding, isFolded, isUnfolded;
-end;
-
--- TODO: Giants question: this is copied from Attachable.getCanAIImplementContinueWork() but when calling it with spec_attachable, it blows up with
--- dataS/scripts/vehicles/specializations/Attachable.lua(1026) : attempt to index local 'jointDesc' (a nil value)
--- The stock Giants getIsLowered() returns true the moment the tool starts moving. What we need however is when
--- the tool is in the final lowered position.
-function courseplay:isLowered(workTool)
-	local spec = workTool.spec_attachable
-	if not workTool:getAINeedsLowering() or not spec then return true end
-	local isLowered = true
-	if spec.lowerAnimation ~= nil then
-		local time = workTool:getAnimationTime(spec.lowerAnimation)
-		isLowered = time == 1 or time == 0
-	end
-	local jointDesc = spec.attacherVehicle:getAttacherJointDescFromObject(workTool)
-	if jointDesc.allowsLowering and workTool:getAINeedsLowering() then
-		if jointDesc.moveDown then
-			isLowered = (jointDesc.moveAlpha == jointDesc.lowerAlpha or jointDesc.moveAlpha == jointDesc.upperAlpha) and isLowered
-		end
-	end
-	return isLowered
-end
-
-function courseplay:isAnimationPartPlaying(workTool, index)
-	if type(index) == "number" then
-		local animPart = workTool.animationParts[index];
-		if animPart == nil then
-			print(nameNum(workTool) .. ": animationParts[" .. tostring(index) .. "] doesn't exist! isAnimationPartPlaying() returns nil");
-			return nil;
-		end;
-		return animPart.clipStartTime == false and animPart.clipEndTime == false;
-	elseif type(index) == "table" then
-		for i,singleIndex in pairs(index) do
-			local animPart = workTool.animationParts[singleIndex];
-			if animPart == nil then
-				print(nameNum(workTool) .. ": animationParts[" .. tostring(singleIndex) .. "] doesn't exist! isAnimationPartPlaying() returns nil");
-				return nil;
-			end;
-			if animPart.clipStartTime == false and animPart.clipEndTime == false then
-				return true;
-			end;
-		end;
-		return false;
-	else
-		print(nameNum(workTool) .. ": type of index doesn't work with animationParts! isAnimationPartPlaying() returns nil");
-		return nil;
-	end;
-end;
-
 function courseplay:round(num, decimals)
 	if num == nil or type(num) ~= "number" then
 		return nil;
@@ -649,7 +577,7 @@ function courseplay.utils:hasVarChanged(vehicle, variableName, direct)
 	local memory = vehicle.cp.varMemory[variableName];
 
 	if (memory == nil and variable ~= nil) or (memory ~= nil and (variable == nil or variable ~= vehicle.cp.varMemory[variableName])) then
-		courseplay:debug(string.format('%s: hasVarChanged(): changed variable %q - old=%q, new=%q', nameNum(vehicle), variableName, tostring(memory), tostring(variable)), courseplay.DBG_12);
+		courseplay:debug(string.format('%s: hasVarChanged(): changed variable %q - old=%q, new=%q', nameNum(vehicle), variableName, tostring(memory), tostring(variable)), courseplay.DBG_UNCATEGORIZED);
 		vehicle.cp.varMemory[variableName] = variable;
 		return true;
 	end;

--- a/hud.lua
+++ b/hud.lua
@@ -611,7 +611,7 @@ function courseplay.hud:updatePageContent(vehicle, page)
 	-- there is a change, they set forceUpdate to force the update of the HUD page, otherwise there's only an empty
 	-- row shown until the page is reselected
 	local forceUpdate = false
-	courseplay:debug(string.format('%s: loadPage(..., %d), set content', nameNum(vehicle), page), courseplay.DBG_18);
+	courseplay:debug(string.format('%s: loadPage(..., %d), set content', nameNum(vehicle), page), courseplay.DBG_HUD);
 	--go through all the HUD stuff and update the content	
 	for line,columns in pairs(vehicle.cp.hud.content.pages[page]) do
 		for column,entry in pairs(columns) do
@@ -1250,7 +1250,7 @@ function courseplay.hud:setReloadPageOrder(vehicle, page, bool)
 
 	if vehicle.cp.hud.reloadPage[page] ~= bool then
 		vehicle.cp.hud.reloadPage[page] = bool;
-		courseplay:debug(string.format('%s: set reloadPage[%d]', nameNum(vehicle), page), courseplay.DBG_18);
+		courseplay:debug(string.format('%s: set reloadPage[%d]', nameNum(vehicle), page), courseplay.DBG_HUD);
 	end;
 end;
 
@@ -1704,7 +1704,7 @@ end
 --update functions 
 function courseplay.hud:updateCourseList(vehicle, page)
 	-- update courses?
-	courseplay.debugVehicle(courseplay.DBG_COURSE_MANAGEMENT, vehicle, 'updateCourseList(): reload courses %s', tostring(vehicle.cp.reloadCourseItems))
+	courseplay.debugVehicle(courseplay.DBG_COURSES, vehicle, 'updateCourseList(): reload courses %s', tostring(vehicle.cp.reloadCourseItems))
 	if vehicle.cp.reloadCourseItems then
 		courseplay.courses:reloadVehicleCourses(vehicle)
 		CourseplayEvent.sendEvent(vehicle,'self.cp.onMpSetCourses',true)
@@ -2320,7 +2320,7 @@ function courseplay.hud:addSettingsRowWithArrows(vehicle,setting,funct, hudPage,
 end
 		
 function courseplay.hud:debug(vehicle,...)
-	courseplay.debugVehicle(courseplay.DBG_18, vehicle, ...)
+	courseplay.debugVehicle(courseplay.DBG_HUD, vehicle, ...)
 end	
 	
 -- do not remove this comment

--- a/input.lua
+++ b/input.lua
@@ -177,7 +177,7 @@ function courseplay:executeFunction(self, func, value, page)
 		-- The new gui click sound
 		g_currentMission.hud.guiSoundPlayer:playSample(GuiSoundPlayer.SOUND_SAMPLES.CLICK)
 	end
-	courseplay:debug(('%s: calling function "%s(%s)"'):format(nameNum(self), tostring(func), tostring(value)), courseplay.DBG_18);
+	courseplay:debug(('%s: calling function "%s(%s)"'):format(nameNum(self), tostring(func), tostring(value)), courseplay.DBG_HUD);
 	if func ~= "rowButton" then
 		--@source: http://stackoverflow.com/questions/1791234/lua-call-function-from-a-string-with-function-name
 		assert(loadstring('courseplay:' .. func .. '(...)'))(self, value);

--- a/recording.lua
+++ b/recording.lua
@@ -163,7 +163,7 @@ function courseplay:setRecordingTurnManeuver(vehicle)
 	else
 		vehicle.cp.hud.recordingTurnManeuverButton:setToolTip(courseplay:loc('COURSEPLAY_RECORDING_TURN_START'));
 	end;
-	courseplay:debug(string.format('%s: set "isRecordingTurnManeuver" to %s', nameNum(vehicle), tostring(vehicle.cp.isRecordingTurnManeuver)), courseplay.DBG_16);
+	courseplay:debug(string.format('%s: set "isRecordingTurnManeuver" to %s', nameNum(vehicle), tostring(vehicle.cp.isRecordingTurnManeuver)), courseplay.DBG_UNCATEGORIZED);
 
 	local cx, cy, cz = getWorldTranslation(vehicle.cp.directionNode);
 	local newAngle = courseplay:currentVehAngle(vehicle);
@@ -192,7 +192,7 @@ function courseplay:setRecordingTurnManeuver(vehicle)
 			turnVerticalDirStr = 'down';
 		end;
 
-		if courseplay.debugChannels[courseplay.DBG_16] then
+		if courseplay.debugChannels[courseplay.DBG_UNCATEGORIZED] then
 			local printStr = '';
 			printStr = printStr .. string.format('\tvx1,vz1=%.2f,%.2f\n', vx1,vz1);
 			printStr = printStr .. string.format('\tvx2,vz2=%.2f,%.2f\n', vx2,vz2);
@@ -276,7 +276,7 @@ end;
 
 function courseplay:setNewWaypointFromRecording(vehicle, cx, cz, angle, wait,unload, rev, crossing, speed, turnStart, turnEnd)
 	vehicle.Waypoints[vehicle.cp.waypointIndex] = { cx = cx, cz = cz, angle = angle, wait = wait,unload = unload, rev = rev, crossing = crossing, speed = speed, turnStart = turnStart, turnEnd = turnEnd };
-	courseplay:debug(string.format('%s: recording: set new waypoint (#%d): cx,cz=%.1f,%.1f, angle=%.1f, wait=%s, rev=%s, crossing=%s, speed=%.5f, turnStart=%s, turnEnd=%s', nameNum(vehicle), vehicle.cp.waypointIndex, cx, cz, angle, tostring(wait), tostring(rev), tostring(crossing), speed, tostring(turnStart), tostring(turnEnd)), courseplay.DBG_16);
+	courseplay:debug(string.format('%s: recording: set new waypoint (#%d): cx,cz=%.1f,%.1f, angle=%.1f, wait=%s, rev=%s, crossing=%s, speed=%.5f, turnStart=%s, turnEnd=%s', nameNum(vehicle), vehicle.cp.waypointIndex, cx, cz, angle, tostring(wait), tostring(rev), tostring(crossing), speed, tostring(turnStart), tostring(turnEnd)), courseplay.DBG_UNCATEGORIZED);
 	vehicle.cp.numWayPoints = vehicle.cp.waypointIndex
 	courseplay.hud:setReloadPageOrder(vehicle, vehicle.cp.hud.currentPage, true)
 end;
@@ -290,7 +290,7 @@ function courseplay:addSplitRecordingPoints(vehicle)
 	local dx, dz = (cx - prevCx) / dist, (cz - prevCz) / dist;
 	local angle = deg(MathUtil.getYRotationFromDirection(dx, dz));
 	local speed = prevPoint.speed;
-	courseplay:debug(('%s: addSplitRecordingPoints: dist=%.1f, numPointsNeeded=%d, angle=%.1f, speed=%.1f'):format(nameNum(vehicle), dist, numPointsNeeded, angle, speed), courseplay.DBG_16);
+	courseplay:debug(('%s: addSplitRecordingPoints: dist=%.1f, numPointsNeeded=%d, angle=%.1f, speed=%.1f'):format(nameNum(vehicle), dist, numPointsNeeded, angle, speed), courseplay.DBG_UNCATEGORIZED);
 
 	-- change previous point sign from 'stop' to 'normal'
 	local oldSignIndex = #vehicle.cp.signs.current;

--- a/reverse.lua
+++ b/reverse.lua
@@ -40,7 +40,7 @@ function courseplay:goReverse(vehicle,lx,lz,mode2)
 			end;
 		end;
 	end;
-	local debugActive = courseplay.debugChannels[courseplay.DBG_13];
+	local debugActive = courseplay.debugChannels[courseplay.DBG_REVERSE];
 	local isNotValid = vehicle.cp.numWorkTools == 0 or workTool == nil or workTool.cp.isPivot == nil or not workTool.cp.frontNode or vehicle.cp.mode == 9;
 	if isNotValid then
 		-- Simple reversing, no trailer to back up, so set the direction and get out of here, no need for
@@ -139,13 +139,13 @@ function courseplay:goReverse(vehicle,lx,lz,mode2)
 					local _,_,z = worldToLocal(workTool.cp.realUnloadOrFillNode, getX(waypoints, waitingPoint), y, getZ(waypoints, waitingPoint));
 					if z >= 0 then
 						courseplay:setWaypointIndex(vehicle, waitingPoint + 1);
-						courseplay:debug(string.format("%s: Is at waiting point", nameNum(vehicle)), courseplay.DBG_13);
+						courseplay:debug(string.format("%s: Is at waiting point", nameNum(vehicle)), courseplay.DBG_REVERSE);
 						break;
 					end;
 				else
 					if distance <= 2 then
 						courseplay:setWaypointIndex(vehicle, waitingPoint + 1);
-						courseplay:debug(string.format("%s: Is at waiting point", nameNum(vehicle)), courseplay.DBG_13);
+						courseplay:debug(string.format("%s: Is at waiting point", nameNum(vehicle)), courseplay.DBG_REVERSE);
 						break;
 					end;
 				end;
@@ -164,10 +164,10 @@ function courseplay:goReverse(vehicle,lx,lz,mode2)
 					local tipRefPoint = workTool.tipReferencePoints[workTool.cp.rearTipRefPoint].node
 					local x,y,z = getWorldTranslation(tipRefPoint);
 					local tipDistanceToPoint = courseplay:distance(x,z,getX(waypoints, unloadPoint),getZ(waypoints, unloadPoint))
-					courseplay:debug(string.format("%s:workTool.cp.rearTipRefPoint: tipDistanceToPoint: %s", nameNum(vehicle),tostring(tipDistanceToPoint)), courseplay.DBG_13);
+					courseplay:debug(string.format("%s:workTool.cp.rearTipRefPoint: tipDistanceToPoint: %s", nameNum(vehicle),tostring(tipDistanceToPoint)), courseplay.DBG_REVERSE);
 					if tipDistanceToPoint  < 0.5 then
 						courseplay:setWaypointIndex(vehicle, unloadPoint + 1);
-						courseplay:debug(string.format("%s: Is at unload point", nameNum(vehicle)), courseplay.DBG_13);
+						courseplay:debug(string.format("%s: Is at unload point", nameNum(vehicle)), courseplay.DBG_REVERSE);
 						break;
 					end;		
 				end
@@ -182,7 +182,7 @@ function courseplay:goReverse(vehicle,lx,lz,mode2)
 			-- SWITCH TO FORWARD
 			elseif waypoints[i-1].rev and not waypoints[i].rev then
 				if distance <= 2 then
-					courseplay:debug(string.format("%s: Change direction to forward", nameNum(vehicle)), courseplay.DBG_13);
+					courseplay:debug(string.format("%s: Change direction to forward", nameNum(vehicle)), courseplay.DBG_REVERSE);
 				end;
 				break;
 
@@ -193,7 +193,7 @@ function courseplay:goReverse(vehicle,lx,lz,mode2)
 					local _,_,tsrZ = worldToLocal(node,srX,yTipper,srZ);
 					if tsrZ < -2 then
 						courseplay:setWaypointIndex(vehicle, recNum);
-						courseplay:debug(string.format("%s: First reverse point -> Change waypoint to behind trailer: %q", nameNum(vehicle), recNum), courseplay.DBG_13);
+						courseplay:debug(string.format("%s: First reverse point -> Change waypoint to behind trailer: %q", nameNum(vehicle), recNum), courseplay.DBG_REVERSE);
 						break;
 					end;
 				end;
@@ -329,7 +329,7 @@ function courseplay:getLocalYRotationToPoint(node, x, y, z, direction)
 end;
 
 function courseplay:showDirection(node,lx,lz, r, g, b)
-	if courseplay.debugChannels[courseplay.DBG_13] then
+	if courseplay.debugChannels[courseplay.DBG_REVERSE] then
 		local x,y,z = getWorldTranslation(node);
 		local ctx,_,ctz = localToWorld(node,lx*5,y,lz*5);
 		cpDebug:drawLine(x, y+5, z, r or 1, g or 0, b or 0, ctx, y+5, ctz);
@@ -340,7 +340,7 @@ end
 function courseplay:getNextFwdPoint(vehicle, isTurning)
 	local directionNode	= AIDriverUtil.getDirectionNode(vehicle)
 	if isTurning then
-		courseplay:debug(('%s: getNextFwdPoint()'):format(nameNum(vehicle)), courseplay.DBG_14);
+		courseplay:debug(('%s: getNextFwdPoint()'):format(nameNum(vehicle)), courseplay.DBG_REVERSE);
     -- scan only the next few waypoints, we don't want to end up way further in the course, missing 
     -- many waypoints. The proper solution here would be to take the workarea into account as the tractor may 
     -- be well ahead of the turnEnd point in case of long implements. Instead we just assume 10 waypoints is
@@ -354,20 +354,21 @@ function courseplay:getNextFwdPoint(vehicle, isTurning)
 				local wpX, wpZ = waypointToCheck.cx, waypointToCheck.cz;
 				local _, _, disZ = worldToLocal(directionNode, wpX, getTerrainHeightAtWorldPos(g_currentMission.terrainRootNode, wpX, 300, wpZ), wpZ);
 				local vX, _, vZ = localToWorld( directionNode, 0, 0, 0 )
-				courseplay:debug(('%s: getNextFwdPoint(), vX = %.1f, vZ = %.1f, i = %d, wpX = %.1f, wpZ = %.1f, disZ = %.1f '):format(nameNum(vehicle), vX, vZ, i, wpX, wpZ, disZ ), courseplay.DBG_14);
+				courseplay:debug(('%s: getNextFwdPoint(), vX = %.1f, vZ = %.1f, i = %d, wpX = %.1f, wpZ = %.1f, disZ = %.1f '):format(
+					nameNum(vehicle), vX, vZ, i, wpX, wpZ, disZ ), courseplay.DBG_REVERSE);
 				if disZ > 5 then
-					courseplay:debug(('--> return (%d) as waypointIndex'):format(i), courseplay.DBG_14);
+					courseplay:debug(('--> return (%d) as waypointIndex'):format(i), courseplay.DBG_REVERSE);
 					return i;
 				end;
 			end;
 		end;
 		local ix = math.min(vehicle.cp.waypointIndex + 1, vehicle.cp.numWaypoints)
-		courseplay:debug(('\tno waypoint found in front of us, returning next waypoint (%d)'):format(ix), courseplay.DBG_14);
+		courseplay:debug(('\tno waypoint found in front of us, returning next waypoint (%d)'):format(ix), courseplay.DBG_REVERSE);
 		return ix
 	else
 		local maxVarianceX = sin(rad(30));
 		local firstFwd, firstFwdOver3;
-		courseplay:debug(('%s: getNextFwdPoint()'):format(nameNum(vehicle)), courseplay.DBG_13);
+		courseplay:debug(('%s: getNextFwdPoint()'):format(nameNum(vehicle)), courseplay.DBG_REVERSE);
 		for i = vehicle.cp.waypointIndex, vehicle.cp.numWaypoints do
 			if not vehicle.Waypoints[i].rev then
 				local x, y, z = getWorldTranslation(directionNode);
@@ -375,54 +376,54 @@ function courseplay:getNextFwdPoint(vehicle, isTurning)
 				local dx,_,dz = worldDirectionToLocal(directionNode, wdx, 0, wdz);
 				if not firstFwd then
 					firstFwd = i;
-					courseplay:debug(('--> set firstFwd as %d'):format(i), courseplay.DBG_13);
+					courseplay:debug(('--> set firstFwd as %d'):format(i), courseplay.DBG_REVERSE);
 				end;
 				if not firstFwdOver3 and dz and dist and dz * dist >= 3 then
 					firstFwdOver3 = i;
-					courseplay:debug(('--> set firstFwdOver3 as %d'):format(i), courseplay.DBG_13);
+					courseplay:debug(('--> set firstFwdOver3 as %d'):format(i), courseplay.DBG_REVERSE);
 				end;
-				courseplay:debug(('--> point %d, dx=%.4f, dz=%.4f, dist=%.2f, maxVarianceX=%.4f'):format(i, dx, dz, dist, maxVarianceX), courseplay.DBG_13);
+				courseplay:debug(('--> point %d, dx=%.4f, dz=%.4f, dist=%.2f, maxVarianceX=%.4f'):format(i, dx, dz, dist, maxVarianceX), courseplay.DBG_REVERSE);
 				if dz > 0 and abs(dx) <= maxVarianceX then -- forward and x angle <= 30°
-					courseplay:debug('----> return as waypointIndex', courseplay.DBG_13);
+					courseplay:debug('----> return as waypointIndex', courseplay.DBG_REVERSE);
 					return i;
 				end;
 			end;
 		end;
 
 		if firstFwdOver3 then
-			courseplay:debug(('\treturn firstFwdOver3 (%d)'):format(firstFwdOver3), courseplay.DBG_13);
+			courseplay:debug(('\treturn firstFwdOver3 (%d)'):format(firstFwdOver3), courseplay.DBG_REVERSE);
 			return firstFwdOver3;
 		elseif firstFwd then
-			courseplay:debug(('\treturn firstFwd (%d)'):format(firstFwd), courseplay.DBG_13);
+			courseplay:debug(('\treturn firstFwd (%d)'):format(firstFwd), courseplay.DBG_REVERSE);
 			return firstFwd;
 		end;
 	end;
 
-	courseplay:debug('\treturn 1', courseplay.DBG_13);
+	courseplay:debug('\treturn 1', courseplay.DBG_REVERSE);
 	return 1;
 end;
 
 function courseplay:getReverseProperties(vehicle, workTool)
-	courseplay:debug(('getReverseProperties(%q, %q)'):format(nameNum(vehicle), nameNum(workTool)), courseplay.DBG_13);
+	courseplay:debug(('getReverseProperties(%q, %q)'):format(nameNum(vehicle), nameNum(workTool)), courseplay.DBG_REVERSE);
 
 	-- Make sure they are reset so they wont conflict when changing worktools
 	workTool.cp.frontNode		= nil;
 	workTool.cp.isPivot			= nil;
 
 	if workTool == vehicle then
-		courseplay:debug('--> workTool is vehicle (steerable) -> return', courseplay.DBG_13);
+		courseplay:debug('--> workTool is vehicle (steerable) -> return', courseplay.DBG_REVERSE);
 		return;
 	end;
 	if vehicle.cp.hasSpecializationShovel then
-		courseplay:debug('--> vehicle has "Shovel" spec -> return', courseplay.DBG_13);
+		courseplay:debug('--> vehicle has "Shovel" spec -> return', courseplay.DBG_REVERSE);
 		return;
 	end;
 	if workTool.cp.hasSpecializationShovel then
-		courseplay:debug('--> workTool has "Shovel" spec -> return', courseplay.DBG_13);
+		courseplay:debug('--> workTool has "Shovel" spec -> return', courseplay.DBG_REVERSE);
 		return;
 	end;
 	if not courseplay:isWheeledWorkTool(workTool) or courseplay:isHookLift(workTool) or courseplay:isAttacherModule(workTool) then
-		courseplay:debug('--> workTool doesn\'t need reverse properties -> return', courseplay.DBG_13);
+		courseplay:debug('--> workTool doesn\'t need reverse properties -> return', courseplay.DBG_REVERSE);
 		return;
 	end;
 
@@ -443,22 +444,22 @@ function courseplay:getReverseProperties(vehicle, workTool)
 	else
 		workTool.cp.frontNode = courseplay:getRealDollyFrontNode(attacherVehicle);
 		if workTool.cp.frontNode then
-			courseplay:debug(string.format('--> workTool %q has dolly', nameNum(workTool)), courseplay.DBG_13);
+			courseplay:debug(string.format('--> workTool %q has dolly', nameNum(workTool)), courseplay.DBG_REVERSE);
 		else
-			courseplay:debug(string.format('--> workTool %q has invalid dolly -> return', nameNum(workTool)), courseplay.DBG_13);
+			courseplay:debug(string.format('--> workTool %q has invalid dolly -> return', nameNum(workTool)), courseplay.DBG_REVERSE);
 			return;
 		end;
 	end;
 
 	workTool.cp.nodeDistance = courseplay:getRealTrailerDistanceToPivot(workTool);
-	courseplay:debug("--> tz: "..tostring(workTool.cp.nodeDistance).."  workTool.cp.realTurningNode: "..tostring(workTool.cp.realTurningNode), courseplay.DBG_13);
+	courseplay:debug("--> tz: "..tostring(workTool.cp.nodeDistance).."  workTool.cp.realTurningNode: "..tostring(workTool.cp.realTurningNode), courseplay.DBG_REVERSE);
 
 	if workTool.cp.realTurningNode == workTool.cp.frontNode then
-		courseplay:debug('--> workTool.cp.realTurningNode == workTool.cp.frontNode', courseplay.DBG_13);
+		courseplay:debug('--> workTool.cp.realTurningNode == workTool.cp.frontNode', courseplay.DBG_REVERSE);
 		workTool.cp.isPivot = false;
 	else
 		workTool.cp.isPivot = true;
 	end;
 
-	courseplay:debug(('--> isPivot=%s, frontNode=%s'):format(tostring(workTool.cp.isPivot), tostring(workTool.cp.frontNode)), courseplay.DBG_13);
+	courseplay:debug(('--> isPivot=%s, frontNode=%s'):format(tostring(workTool.cp.isPivot), tostring(workTool.cp.frontNode)), courseplay.DBG_REVERSE);
 end;

--- a/settings.lua
+++ b/settings.lua
@@ -146,7 +146,6 @@ function courseplay:changeCombineOffset(vehicle, changeBy)
 		vehicle.cp.combineOffsetAutoMode = true;
 	end;
 
-	courseplay:debug(nameNum(vehicle) .. ": manual combine_offset change: prev " .. previousOffset .. " // new " .. vehicle.cp.combineOffset .. " // auto = " .. tostring(vehicle.cp.combineOffsetAutoMode), courseplay.DBG_MODE_2_3);
 end
 
 function courseplay:changeTipperOffset(vehicle, changeBy)
@@ -469,7 +468,7 @@ function courseplay.settings.setReloadCourseItems(vehicle)
 		for k,v in pairs(g_currentMission.enterables) do
 			if v.hasCourseplaySpec then -- alternative way to check if SpecializationUtil.hasSpecialization(courseplay, v.specializations)
 				v.cp.reloadCourseItems = true
-				courseplay.debugVehicle(courseplay.DBG_COURSE_MANAGEMENT, v,"courseplay.hud:setReloadPageOrder(%s, 2, true) TypeName: %s ;",tostring(v.name), v.typeName)
+				courseplay.debugVehicle(courseplay.DBG_COURSES, v,"courseplay.hud:setReloadPageOrder(%s, 2, true) TypeName: %s ;",tostring(v.name), v.typeName)
 				courseplay.hud:setReloadPageOrder(v, 2, true);
 			end
 		end
@@ -761,7 +760,7 @@ end;
 function courseplay:toggleHeadlandOrder(vehicle)
 	vehicle.cp.headland.orderBefore = not vehicle.cp.headland.orderBefore;
 	--vehicle.cp.headland.orderButton:setSpriteSectionUVs(vehicle.cp.headland.orderBefore and 'headlandOrdBef' or 'headlandOrdAft');
-	-- courseplay:debug(string.format('toggleHeadlandOrder(): orderBefore=%s -> set to %q, setOverlay(orderButton, %d)', tostring(not vehicle.cp.headland.orderBefore), tostring(vehicle.cp.headland.orderBefore), vehicle.cp.headland.orderBefore and 1 or 2), courseplay.DBG_COURSE_GENERATOR);
+	-- courseplay:debug(string.format('toggleHeadlandOrder(): orderBefore=%s -> set to %q, setOverlay(orderButton, %d)', tostring(not vehicle.cp.headland.orderBefore), tostring(vehicle.cp.headland.orderBefore), vehicle.cp.headland.orderBefore and 1 or 2), courseplay.DBG_COURSES);
 end;
 
 function courseplay:changeIslandBypassMode(vehicle)
@@ -825,21 +824,25 @@ function courseplay:validateCourseGenerationData(vehicle)
 	end;
 	--courseplay.buttons:setActiveEnabled(vehicle, 'generateCourse');
 
-	courseplay:debug(string.format("%s: hasGeneratedCourse=%s, hasEnoughWaypoints=%s, hasStartingCorner=%s, hasStartingDirection=%s, numCourses=%s, fieldEdge.selectedField.fieldNum=%s ==> hasValidCourseGenerationData=%s", nameNum(vehicle), tostring(vehicle.cp.hasGeneratedCourse), tostring(hasEnoughWaypoints), tostring(vehicle.cp.hasStartingCorner), tostring(vehicle.cp.hasStartingDirection), tostring(vehicle.cp.numCourses), tostring(vehicle.cp.fieldEdge.selectedField.fieldNum), tostring(vehicle.cp.hasValidCourseGenerationData)), courseplay.DBG_COURSE_GENERATOR);
+	courseplay:debug(string.format("%s: hasGeneratedCourse=%s, hasEnoughWaypoints=%s, hasStartingCorner=%s, hasStartingDirection=%s, numCourses=%s, fieldEdge.selectedField.fieldNum=%s ==> hasValidCourseGenerationData=%s",
+		nameNum(vehicle), tostring(vehicle.cp.hasGeneratedCourse), tostring(hasEnoughWaypoints), tostring(vehicle.cp.hasStartingCorner), tostring(vehicle.cp.hasStartingDirection), tostring(vehicle.cp.numCourses), tostring(vehicle.cp.fieldEdge.selectedField.fieldNum), tostring(vehicle.cp.hasValidCourseGenerationData)), courseplay.DBG_COURSES);
 end;
 
 function courseplay:validateCanSwitchMode(vehicle)
-	vehicle:setCpVar('canSwitchMode', not vehicle:getIsCourseplayDriving() and not vehicle.cp.isRecording and not vehicle.cp.recordingIsPaused and not vehicle.cp.fieldEdge.customField.isCreated,courseplay.isClient);
-	courseplay:debug(('%s: validateCanSwitchMode(): isDriving=%s, isRecording=%s, recordingIsPaused=%s, customField.isCreated=%s ==> canSwitchMode=%s'):format(nameNum(vehicle), tostring(vehicle:getIsCourseplayDriving()), tostring(vehicle.cp.isRecording), tostring(vehicle.cp.recordingIsPaused), tostring(vehicle.cp.fieldEdge.customField.isCreated), tostring(vehicle.cp.canSwitchMode)), courseplay.DBG_12);
+	vehicle:setCpVar('canSwitchMode', not vehicle:getIsCourseplayDriving() and not vehicle.cp.isRecording and
+		not vehicle.cp.recordingIsPaused and not vehicle.cp.fieldEdge.customField.isCreated,courseplay.isClient);
+	courseplay:debug(('%s: validateCanSwitchMode(): isDriving=%s, isRecording=%s, recordingIsPaused=%s, customField.isCreated=%s ==> canSwitchMode=%s'):format(
+		nameNum(vehicle), tostring(vehicle:getIsCourseplayDriving()), tostring(vehicle.cp.isRecording),
+		tostring(vehicle.cp.recordingIsPaused), tostring(vehicle.cp.fieldEdge.customField.isCreated), tostring(vehicle.cp.canSwitchMode)), courseplay.DBG_UNCATEGORIZED);
 end;
 
 function courseplay:reloadCoursesFromXML(vehicle)
-	courseplay:debug("reloadCoursesFromXML()", courseplay.DBG_COURSE_MANAGEMENT);
+	courseplay:debug("reloadCoursesFromXML()", courseplay.DBG_COURSES);
 	if g_server ~= nil then
 		courseplay.courses:loadCoursesAndFoldersFromXml();
 
-		--courseplay:debug(tableShow(g_currentMission.cp_courses, "g_cM cp_courses", 8), courseplay.DBG_COURSE_MANAGEMENT);
-		courseplay:debug("g_currentMission.cp_courses = courseplay.courses:loadCoursesAndFoldersFromXml()", courseplay.DBG_COURSE_MANAGEMENT);
+		--courseplay:debug(tableShow(g_currentMission.cp_courses, "g_cM cp_courses", 8), courseplay.DBG_COURSES);
+		courseplay:debug("g_currentMission.cp_courses = courseplay.courses:loadCoursesAndFoldersFromXml()", courseplay.DBG_COURSES);
 		if not vehicle:getIsCourseplayDriving() then
 			local loadedCoursesBackup = vehicle.cp.loadedCourses;
 			courseplay:clearCurrentLoadedCourse(vehicle);
@@ -1088,7 +1091,7 @@ end;
 
 function courseplay:setSlippingStage(vehicle, stage)
 	if vehicle.cp.slippingStage ~= stage then
-		courseplay:debug(('%s: setSlippingStage(..., %d)'):format(nameNum(vehicle), stage), courseplay.DBG_14);
+		courseplay:debug(('%s: setSlippingStage(..., %d)'):format(nameNum(vehicle), stage), courseplay.DBG_AI_DRIVER);
 		vehicle.cp.slippingStage = stage;
 	end;
 end;
@@ -1754,7 +1757,7 @@ function AutoDriveModeSetting:init(vehicle)
 end
 
 function AutoDriveModeSetting:next()
-	courseplay.debugVehicle(courseplay.DBG_12, vehicle, 'AutoDrive mode: %d', vehicle.cp.settings.autoDriveMode:get())
+	courseplay.debugVehicle(courseplay.DBG_UNCATEGORIZED, self.vehicle, 'AutoDrive mode: %d', self.vehicle.cp.settings.autoDriveMode:get())
 	SettingList.next(self)
 end
 

--- a/signs.lua
+++ b/signs.lua
@@ -129,7 +129,7 @@ end;
 
 function courseplay.signs:updateWaypointSigns(vehicle, section, idx)
 	section = section or 'all'; --section: 'all', 'crossing', 'current'
-	courseplay.debugVehicle(courseplay.DBG_COURSE_MANAGEMENT, vehicle, 'Updating waypoint display for %s', section)
+	courseplay.debugVehicle(courseplay.DBG_COURSES, vehicle, 'Updating waypoint display for %s', section)
 	vehicle.cp.numWaitPoints = 0;
 	vehicle.cp.numCrossingPoints = 0;
 	vehicle:setCpVar('numWaypoints', #vehicle.Waypoints,courseplay.isClient);
@@ -286,7 +286,7 @@ function courseplay.signs:setSignsVisibility(vehicle, forceHide)
 	local showVisualWaypointsState = vehicle.cp.settings.showVisualWaypoints:get()
 	
 	local numSigns = #vehicle.cp.signs.current;
-	courseplay.debugVehicle(courseplay.DBG_COURSE_MANAGEMENT, vehicle, 'Setting visibility for %d waypoints, start/end=%s all=%s, xing=%s', numSigns,
+	courseplay.debugVehicle(courseplay.DBG_COURSES, vehicle, 'Setting visibility for %d waypoints, start/end=%s all=%s, xing=%s', numSigns,
 		tostring(vehicle.cp.visualWaypointsStartEnd), tostring(vehicle.cp.visualWaypointsAll), tostring(vehicle.cp.visualWaypointsCrossing))
 	local vis, isStartEndPoint;
 	for k,signData in pairs(vehicle.cp.signs.current) do

--- a/start_stop.lua
+++ b/start_stop.lua
@@ -110,7 +110,8 @@ function courseplay:start(self)
 	self.cp.numWaitPoints = numWaitPoints;
 	self.cp.numUnloadPoints = numUnloadPoints;
 	self.cp.numCrossingPoints = numCrossingPoints;
-	courseplay:debug(string.format("%s: numWaitPoints=%d, waitPoints[1]=%s, numCrossingPoints=%d", nameNum(self), self.cp.numWaitPoints, tostring(self.cp.waitPoints[1]), numCrossingPoints), courseplay.DBG_12);
+	courseplay:debug(string.format("%s: numWaitPoints=%d, waitPoints[1]=%s, numCrossingPoints=%d",
+		nameNum(self), self.cp.numWaitPoints, tostring(self.cp.waitPoints[1]), numCrossingPoints), courseplay.DBG_COURSES);
 
 	-- set waitTime to 0 if necessary
 	if not courseplay:getCanHaveWaitTime(self) and self.cp.waitTime > 0 then

--- a/test/mock-Courseplay.lua
+++ b/test/mock-Courseplay.lua
@@ -26,7 +26,7 @@ function courseplay.lowerImplements() end
 function courseplay.raiseImplements() end
 
 courseplay.debugChannels = {}
-courseplay.debugChannels[courseplay.DBG_12] = true
+courseplay.debugChannels[courseplay.DBG_PPC] = true
 
 courseplay.settings = {}
 courseplay.hud = {}

--- a/triggers.lua
+++ b/triggers.lua
@@ -186,7 +186,7 @@ function courseplay:findSpecialTriggerCallback(transformId, x, y, z, distance)
 		return true;
 	end;
 	
-	if courseplay.debugChannels[courseplay.DBG_19] then
+	if courseplay.debugChannels[courseplay.DBG_TRIGGERS] then
 		cpDebug:drawPoint(x, y, z, 1, 1, 0);
 	end;
 	
@@ -195,7 +195,7 @@ function courseplay:findSpecialTriggerCallback(transformId, x, y, z, distance)
 	local parent = getParent(transformId);
 	for _,implement in pairs(self:getAttachedImplements()) do
 		if (implement.object ~= nil and implement.object.rootNode == parent) then
-			courseplay:debug(('%s: trigger %s is from my own implement'):format(nameNum(self), tostring(transformId)), courseplay.DBG_19);
+			courseplay:debug(('%s: trigger %s is from my own implement'):format(nameNum(self), tostring(transformId)), courseplay.DBG_TRIGGERS);
 			return true
 		end
 	end	
@@ -208,23 +208,23 @@ function courseplay:findSpecialTriggerCallback(transformId, x, y, z, distance)
 		for _,workTool in pairs (self.cp.workTools) do
 			if (trigger.onActivateObject and trigger.getIsActivatable and trigger:getIsActivatable(workTool))
 			or (trigger.sourceObject and  #workTool.spec_fillUnit.fillTrigger.triggers > 0 and workTool.spec_fillUnit.fillTrigger.triggers[1] == trigger) then 
-				courseplay:debug(('%s: %s is allready in fillTrigger(%d)'):format(nameNum(self),tostring(workTool:getName()), transformId), courseplay.DBG_19);
+				courseplay:debug(('%s: %s is allready in fillTrigger(%d)'):format(nameNum(self),tostring(workTool:getName()), transformId), courseplay.DBG_TRIGGERS);
 				imNotInThisTrigger = false
 			end
 		end
 		if imNotInThisTrigger then
-			courseplay:debug(('%s: fillTrigger(%d) found, add to vehicle.cp.fillTriggers'):format(nameNum(self), transformId), courseplay.DBG_19);
+			courseplay:debug(('%s: fillTrigger(%d) found, add to vehicle.cp.fillTriggers'):format(nameNum(self), transformId), courseplay.DBG_TRIGGERS);
 			courseplay:addFoundFillTrigger(self, transformId)
 			courseplay:setCustomTimer(self, 'triggerFailBackup', 10);
 		else
-			courseplay:debug(('%s: fillTrigger(%d) found, but Im allready in it so ignore it'):format(nameNum(self), transformId), courseplay.DBG_19);
+			courseplay:debug(('%s: fillTrigger(%d) found, but Im allready in it so ignore it'):format(nameNum(self), transformId), courseplay.DBG_TRIGGERS);
 		end
 		return false;
 	end
 			
 	CpManager.confirmedNoneSpecialTriggers[transformId] = true;
 	CpManager.confirmedNoneSpecialTriggersCounter = CpManager.confirmedNoneSpecialTriggersCounter + 1;
-	courseplay:debug(('%s: added %d (%s) to trigger blacklist -> total=%d'):format(nameNum(self), transformId, name, CpManager.confirmedNoneSpecialTriggersCounter), courseplay.DBG_19);
+	courseplay:debug(('%s: added %d (%s) to trigger blacklist -> total=%d'):format(nameNum(self), transformId, name, CpManager.confirmedNoneSpecialTriggersCounter), courseplay.DBG_TRIGGERS);
 
 	return true;
 end;
@@ -232,7 +232,7 @@ end;
 function courseplay:addFoundFillTrigger(vehicle, transformId)
 	--if we dont have a fillTrigger, set cp.fillTrigger
 	if vehicle.cp.fillTrigger == nil then
-		courseplay:debug(string.format("set %s as vehicle.cp.fillTrigger",tostring(transformId)),courseplay.DBG_19)
+		courseplay:debug(string.format("set %s as vehicle.cp.fillTrigger",tostring(transformId)),courseplay.DBG_TRIGGERS)
 		vehicle.cp.fillTrigger = transformId;
 	end
 	-- check whether we have it in our list allready
@@ -248,7 +248,7 @@ function courseplay:addFoundFillTrigger(vehicle, transformId)
 	--if not, add it
 	if not allreadyThere then
 		table.insert(vehicle.cp.fillTriggers,transformId)
-		courseplay.debugVehicle(courseplay.DBG_19,vehicle,'add %s to vehicle.cp.fillTriggers; new number of triggers: %d',tostring(transformId),#vehicle.cp.fillTriggers)
+		courseplay.debugVehicle(courseplay.DBG_TRIGGERS,vehicle,'add %s to vehicle.cp.fillTriggers; new number of triggers: %d',tostring(transformId),#vehicle.cp.fillTriggers)
 	end
 end
 
@@ -258,7 +258,7 @@ function courseplay:findFuelTriggerCallback(transformId, x, y, z, distance)
 		return true;
 	end;
 		
-	if courseplay.debugChannels[courseplay.DBG_19] then
+	if courseplay.debugChannels[courseplay.DBG_TRIGGERS] then
 		cpDebug:drawPoint(x, y, z, 1, 1, 0);
 	end;
 	
@@ -267,7 +267,7 @@ function courseplay:findFuelTriggerCallback(transformId, x, y, z, distance)
 	local parent = getParent(transformId);
 	for _,implement in pairs(self:getAttachedImplements()) do
 		if (implement.object ~= nil and implement.object.rootNode == parent) then
-			courseplay:debug(('%s: trigger %s is from my own implement'):format(nameNum(self), tostring(transformId)), courseplay.DBG_19);
+			courseplay:debug(('%s: trigger %s is from my own implement'):format(nameNum(self), tostring(transformId)), courseplay.DBG_TRIGGERS);
 			return true
 		end
 	end	
@@ -283,7 +283,7 @@ function courseplay:findFuelTriggerCallback(transformId, x, y, z, distance)
 			
 	CpManager.confirmedNoneSpecialTriggers[transformId] = true;
 	CpManager.confirmedNoneSpecialTriggersCounter = CpManager.confirmedNoneSpecialTriggersCounter + 1;
-	courseplay:debug(('%s: added %d (%s) to trigger blacklist -> total=%d'):format(nameNum(self), transformId, name, CpManager.confirmedNoneSpecialTriggersCounter), courseplay.DBG_19);
+	courseplay:debug(('%s: added %d (%s) to trigger blacklist -> total=%d'):format(nameNum(self), transformId, name, CpManager.confirmedNoneSpecialTriggersCounter), courseplay.DBG_TRIGGERS);
 
 	return true;
 end;

--- a/turn.lua
+++ b/turn.lua
@@ -40,7 +40,7 @@ function courseplay:turn(vehicle, dt, turnContext)
 	----------------------------------------------------------
 	-- Debug prints
 	----------------------------------------------------------
-	if courseplay.debugChannels[courseplay.DBG_14] then
+	if courseplay.debugChannels[courseplay.DBG_TURN] then
 		if #vehicle.cp.turnTargets > 0 then
 			-- Draw debug points for waypoints.
 			for index, turnTarget in ipairs(vehicle.cp.turnTargets) do
@@ -171,7 +171,7 @@ function courseplay:turn(vehicle, dt, turnContext)
 	local cx,cz = turnContext.turnEndWp.x, turnContext.turnEndWp.z
 
 	--- Debug Print
-	if courseplay.debugChannels[courseplay.DBG_14] then
+	if courseplay.debugChannels[courseplay.DBG_TURN] then
 		local x,y,z = getWorldTranslation(turnInfo.targetNode);
 		local ctx,_,ctz = localToWorld(turnInfo.targetNode, 0, 0, 20);
 		--drawDebugLine(x, y+5, z, 1, 0, 0, ctx, y+5, ctz, 0, 1, 0);
@@ -183,7 +183,7 @@ function courseplay:turn(vehicle, dt, turnContext)
 
 	--- Get the local delta distances from the tractor to the targetNode
 	turnInfo.targetDeltaX, _, turnInfo.targetDeltaZ = worldToLocal(turnInfo.directionNode, cx, vehicleY, cz);
-	courseplay:debug(string.format("%s:(Turn) targetDeltaX=%.2f, targetDeltaZ=%.2f", nameNum(vehicle), turnInfo.targetDeltaX, turnInfo.targetDeltaZ), courseplay.DBG_14);
+	courseplay:debug(string.format("%s:(Turn) targetDeltaX=%.2f, targetDeltaZ=%.2f", nameNum(vehicle), turnInfo.targetDeltaX, turnInfo.targetDeltaZ), courseplay.DBG_TURN);
 
 	--- Get the turn direction
 	if turnContext:isHeadlandCorner() then
@@ -225,19 +225,19 @@ function courseplay:turn(vehicle, dt, turnContext)
 		turnInfo.reverseOffset = offset;
 	end;
 
-	courseplay:debug(("%s:(Turn Data) frontMarker=%q, backMarker=%q, halfVehicleWidth=%q, directionNodeToTurnNodeLength=%q, wpChangeDistance=%q"):format(nameNum(vehicle), tostring(turnInfo.frontMarker), tostring(backMarker), tostring(turnInfo.halfVehicleWidth), tostring(turnInfo.directionNodeToTurnNodeLength), tostring(turnInfo.wpChangeDistance)), courseplay.DBG_14);
-	courseplay:debug(("%s:(Turn Data) reverseWPChangeDistance=%q, direction=%q, haveHeadlands=%q, headlandHeight=%q"):format(nameNum(vehicle), tostring(turnInfo.reverseWPChangeDistance), tostring(turnInfo.direction), tostring(turnInfo.haveHeadlands), tostring(turnInfo.headlandHeight)), courseplay.DBG_14);
-	courseplay:debug(("%s:(Turn Data) numLanes=%q, onLaneNum=%q, turnOnField=%q, reverseOffset=%q"):format(nameNum(vehicle), tostring(turnInfo.numLanes), tostring(turnInfo.onLaneNum), tostring(turnInfo.turnOnField), tostring(turnInfo.reverseOffset)), courseplay.DBG_14);
-	courseplay:debug(("%s:(Turn Data) haveWheeledImplement=%q, reversingWorkTool=%q, turnRadius=%q, turnDiameter=%q"):format(nameNum(vehicle), tostring(turnInfo.haveWheeledImplement), tostring(turnInfo.reversingWorkTool), tostring(turnInfo.turnRadius), tostring(turnInfo.turnDiameter)), courseplay.DBG_14);
-	courseplay:debug(("%s:(Turn Data) targetNode=%q, targetDeltaX=%q, targetDeltaZ=%q, zOffset=%q"):format(nameNum(vehicle), tostring(turnInfo.targetNode), tostring(turnInfo.targetDeltaX), tostring(turnInfo.targetDeltaZ), tostring(turnInfo.zOffset)), courseplay.DBG_14);
-	courseplay:debug(("%s:(Turn Data) reverseOffset=%q, isHarvester=%q, noReverse=%q"):format(nameNum(vehicle), tostring(turnInfo.reverseOffset), tostring(turnInfo.isHarvester), tostring(turnInfo.noReverse)), courseplay.DBG_14);
+	courseplay:debug(("%s:(Turn Data) frontMarker=%q, backMarker=%q, halfVehicleWidth=%q, directionNodeToTurnNodeLength=%q, wpChangeDistance=%q"):format(nameNum(vehicle), tostring(turnInfo.frontMarker), tostring(backMarker), tostring(turnInfo.halfVehicleWidth), tostring(turnInfo.directionNodeToTurnNodeLength), tostring(turnInfo.wpChangeDistance)), courseplay.DBG_TURN);
+	courseplay:debug(("%s:(Turn Data) reverseWPChangeDistance=%q, direction=%q, haveHeadlands=%q, headlandHeight=%q"):format(nameNum(vehicle), tostring(turnInfo.reverseWPChangeDistance), tostring(turnInfo.direction), tostring(turnInfo.haveHeadlands), tostring(turnInfo.headlandHeight)), courseplay.DBG_TURN);
+	courseplay:debug(("%s:(Turn Data) numLanes=%q, onLaneNum=%q, turnOnField=%q, reverseOffset=%q"):format(nameNum(vehicle), tostring(turnInfo.numLanes), tostring(turnInfo.onLaneNum), tostring(turnInfo.turnOnField), tostring(turnInfo.reverseOffset)), courseplay.DBG_TURN);
+	courseplay:debug(("%s:(Turn Data) haveWheeledImplement=%q, reversingWorkTool=%q, turnRadius=%q, turnDiameter=%q"):format(nameNum(vehicle), tostring(turnInfo.haveWheeledImplement), tostring(turnInfo.reversingWorkTool), tostring(turnInfo.turnRadius), tostring(turnInfo.turnDiameter)), courseplay.DBG_TURN);
+	courseplay:debug(("%s:(Turn Data) targetNode=%q, targetDeltaX=%q, targetDeltaZ=%q, zOffset=%q"):format(nameNum(vehicle), tostring(turnInfo.targetNode), tostring(turnInfo.targetDeltaX), tostring(turnInfo.targetDeltaZ), tostring(turnInfo.zOffset)), courseplay.DBG_TURN);
+	courseplay:debug(("%s:(Turn Data) reverseOffset=%q, isHarvester=%q, noReverse=%q"):format(nameNum(vehicle), tostring(turnInfo.reverseOffset), tostring(turnInfo.isHarvester), tostring(turnInfo.noReverse)), courseplay.DBG_TURN);
 
 
 	if not turnContext:isHeadlandCorner() then
 		----------------------------------------------------------
 		-- SWITCH TO THE NEXT LANE
 		----------------------------------------------------------
-		courseplay:debug(string.format("%s:(Turn) Direction difference is %.1f, this is a lane switch.", nameNum(vehicle), turnContext.directionChangeDeg), courseplay.DBG_14);
+		courseplay:debug(string.format("%s:(Turn) Direction difference is %.1f, this is a lane switch.", nameNum(vehicle), turnContext.directionChangeDeg), courseplay.DBG_TURN);
 		----------------------------------------------------------
 		-- WIDE TURNS (Turns where the distance to next lane is bigger than the turning Diameter)
 		----------------------------------------------------------
@@ -305,15 +305,15 @@ function courseplay:turn(vehicle, dt, turnContext)
 		courseplay.generateTurnTypeHeadlandCornerReverseStraightTractor(vehicle, turnInfo)
 	end
 
-	courseplay.debugLine(courseplay.DBG_14, 1);
-	courseplay:debug(string.format("%s:(Turn) Generated %d Turn Waypoints", nameNum(vehicle), #vehicle.cp.turnTargets), courseplay.DBG_14);
-	courseplay.debugLine(courseplay.DBG_14, 3);
+	courseplay.debugLine(courseplay.DBG_TURN, 1);
+	courseplay:debug(string.format("%s:(Turn) Generated %d Turn Waypoints", nameNum(vehicle), #vehicle.cp.turnTargets), courseplay.DBG_TURN);
+	courseplay.debugLine(courseplay.DBG_TURN, 3);
 end
 
 function courseplay:generateTurnTypeWideTurn(vehicle, turnInfo)
-	courseplay.debugLine(courseplay.DBG_14, 3);
-	courseplay:debug(string.format("%s:(Turn) Using Wide Turn", nameNum(vehicle)), courseplay.DBG_14);
-	courseplay.debugLine(courseplay.DBG_14, 3);
+	courseplay.debugLine(courseplay.DBG_TURN, 3);
+	courseplay:debug(string.format("%s:(Turn) Using Wide Turn", nameNum(vehicle)), courseplay.DBG_TURN);
+	courseplay.debugLine(courseplay.DBG_TURN, 3);
 
 	local posX, posZ;
 	local fromPoint, toPoint = {}, {};
@@ -392,9 +392,9 @@ function courseplay:generateTurnTypeWideTurn(vehicle, turnInfo)
 end;
 
 function courseplay:generateTurnTypeWideTurnWithAvoidance(vehicle, turnInfo)
-	courseplay.debugLine(courseplay.DBG_14, 3);
-	courseplay:debug(string.format("%s:(Turn) Using Wide Turn With Corner Avoidance", nameNum(vehicle)), courseplay.DBG_14);
-	courseplay.debugLine(courseplay.DBG_14, 3);
+	courseplay.debugLine(courseplay.DBG_TURN, 3);
+	courseplay:debug(string.format("%s:(Turn) Using Wide Turn With Corner Avoidance", nameNum(vehicle)), courseplay.DBG_TURN);
+	courseplay.debugLine(courseplay.DBG_TURN, 3);
 
 	local posX, posZ;
 	local fromPoint, toPoint = {}, {};
@@ -511,9 +511,9 @@ function courseplay:generateTurnTypeWideTurnWithAvoidance(vehicle, turnInfo)
 end;
 
 function courseplay:generateTurnTypeOhmTurn(vehicle, turnInfo)
-	courseplay.debugLine(courseplay.DBG_14, 3);
-	courseplay:debug(string.format("%s:(Turn) Using Ohm Turn", nameNum(vehicle)), courseplay.DBG_14);
-	courseplay.debugLine(courseplay.DBG_14, 3);
+	courseplay.debugLine(courseplay.DBG_TURN, 3);
+	courseplay:debug(string.format("%s:(Turn) Using Ohm Turn", nameNum(vehicle)), courseplay.DBG_TURN);
+	courseplay.debugLine(courseplay.DBG_TURN, 3);
 
 	local posX, posZ;
 
@@ -559,9 +559,9 @@ function courseplay:generateTurnTypeOhmTurn(vehicle, turnInfo)
 end;
 
 function courseplay:generateTurnTypeQuestionmarkTurn(vehicle, turnInfo)
-	courseplay.debugLine(courseplay.DBG_14, 3);
-	courseplay:debug(string.format("%s:(Turn) Using Questionmark Turn", nameNum(vehicle)), courseplay.DBG_14);
-	courseplay.debugLine(courseplay.DBG_14, 3);
+	courseplay.debugLine(courseplay.DBG_TURN, 3);
+	courseplay:debug(string.format("%s:(Turn) Using Questionmark Turn", nameNum(vehicle)), courseplay.DBG_TURN);
+	courseplay.debugLine(courseplay.DBG_TURN, 3);
 
 	local posX, posZ;
 	local fromPoint, toPoint = {}, {};
@@ -575,7 +575,7 @@ function courseplay:generateTurnTypeQuestionmarkTurn(vehicle, turnInfo)
 	local sideC = turnInfo.turnDiameter;
 	local sideB = turnInfo.turnRadius + centerOffset;
 	local centerHeight = square(sideC^2 - sideB^2);
-	courseplay:debug(("%s:(Turn) centerOffset=%s, sideB=%s, sideC=%s, centerHeight=%s"):format(nameNum(vehicle), tostring(centerOffset), tostring(sideB), tostring(sideC), tostring(centerHeight)), courseplay.DBG_14);
+	courseplay:debug(("%s:(Turn) centerOffset=%s, sideB=%s, sideC=%s, centerHeight=%s"):format(nameNum(vehicle), tostring(centerOffset), tostring(sideB), tostring(sideC), tostring(centerHeight)), courseplay.DBG_TURN);
 
 	--- Check if we can turn on the headlands
 	local spaceNeeded = 0;
@@ -589,7 +589,7 @@ function courseplay:generateTurnTypeQuestionmarkTurn(vehicle, turnInfo)
 		canTurnOnHeadland = true;
 	end;
 
-	courseplay:debug(("%s:(Turn) canTurnOnHeadland=%s, headlandHeight=%.2fm, spaceNeeded=%.2fm"):format(nameNum(vehicle), tostring(canTurnOnHeadland), turnInfo.headlandHeight, spaceNeeded), courseplay.DBG_14);
+	courseplay:debug(("%s:(Turn) canTurnOnHeadland=%s, headlandHeight=%.2fm, spaceNeeded=%.2fm"):format(nameNum(vehicle), tostring(canTurnOnHeadland), turnInfo.headlandHeight, spaceNeeded), courseplay.DBG_TURN);
 
 	--- Target is behind of us
 	local targetOffsetZ = 0;
@@ -610,7 +610,7 @@ function courseplay:generateTurnTypeQuestionmarkTurn(vehicle, turnInfo)
 	if turnInfo.frontMarker > 0 and turnInfo.backMarker > 0 then
 		extraMoveBack = turnInfo.frontMarker;
 	end;
-	courseplay:debug(("%s:(Turn) targetOffsetZ=%s, extraMoveBack=%.2fm"):format(nameNum(vehicle), tostring(targetOffsetZ), extraMoveBack), courseplay.DBG_14);
+	courseplay:debug(("%s:(Turn) targetOffsetZ=%s, extraMoveBack=%.2fm"):format(nameNum(vehicle), tostring(targetOffsetZ), extraMoveBack), courseplay.DBG_TURN);
 
 	--- Get the center height offset
 	local centerHeightOffset = -targetOffsetZ + turnInfo.reverseOffset + extraMoveBack;
@@ -625,16 +625,16 @@ function courseplay:generateTurnTypeQuestionmarkTurn(vehicle, turnInfo)
 	if vehicle.cp.settings.oppositeTurnMode:is(true) then
 		width = turnInfo.onLaneNum * vehicle.cp.courseWorkWidth - (vehicle.cp.courseWorkWidth * 0.5);
 		doNormalTurn = (turnInfo.haveHeadlands and widthNeeded > (width + turnInfo.headlandHeight) or widthNeeded > width);
-		courseplay:debug(("%s:(Turn) doNormalTurn=%s, haveHeadlands=%s, %.1fm > %.1fm"):format(nameNum(vehicle), tostring(doNormalTurn), tostring(turnInfo.haveHeadlands), widthNeeded, (turnInfo.haveHeadlands and (width + turnInfo.headlandHeight) or width)), courseplay.DBG_14);
+		courseplay:debug(("%s:(Turn) doNormalTurn=%s, haveHeadlands=%s, %.1fm > %.1fm"):format(nameNum(vehicle), tostring(doNormalTurn), tostring(turnInfo.haveHeadlands), widthNeeded, (turnInfo.haveHeadlands and (width + turnInfo.headlandHeight) or width)), courseplay.DBG_TURN);
 	else
 		width = (turnInfo.numLanes - turnInfo.onLaneNum) * vehicle.cp.courseWorkWidth - (vehicle.cp.courseWorkWidth * 0.5);
 		doNormalTurn = (turnInfo.haveHeadlands and widthNeeded < (width + turnInfo.headlandHeight) or widthNeeded < width);
-		courseplay:debug(("%s:(Turn) doNormalTurn=%s, haveHeadlands=%s, %.1fm < %.1fm"):format(nameNum(vehicle), tostring(doNormalTurn), tostring(turnInfo.haveHeadlands), widthNeeded, (turnInfo.haveHeadlands and (width + turnInfo.headlandHeight) or width)), courseplay.DBG_14);
+		courseplay:debug(("%s:(Turn) doNormalTurn=%s, haveHeadlands=%s, %.1fm < %.1fm"):format(nameNum(vehicle), tostring(doNormalTurn), tostring(turnInfo.haveHeadlands), widthNeeded, (turnInfo.haveHeadlands and (width + turnInfo.headlandHeight) or width)), courseplay.DBG_TURN);
 	end;
 
 	--- Do the opposite direction turns for bale loaders, so we avoid bales in the normal turn direction
 	if doNormalTurn and isReverseingBaleLoader then
-		courseplay.debugVehicle(courseplay.DBG_14, vehicle, '(Turn) opposite direction for bale loaders to avoid bales')
+		courseplay.debugVehicle(courseplay.DBG_TURN, vehicle, '(Turn) opposite direction for bale loaders to avoid bales')
 		doNormalTurn = false;
 	end;
 
@@ -660,7 +660,7 @@ function courseplay:generateTurnTypeQuestionmarkTurn(vehicle, turnInfo)
 
 		--- Get the new zOffset
 		local newZOffset = centerHeight + centerHeightOffset;
-		courseplay:debug(("%s:(Turn) centerHeightOffset=%s, reverseOffset=%s, zOffset=%s, turnRadius=%s"):format(nameNum(vehicle), tostring(centerHeightOffset), tostring(turnInfo.reverseOffset), tostring(turnInfo.zOffset), tostring(turnInfo.turnRadius)), courseplay.DBG_14);
+		courseplay:debug(("%s:(Turn) centerHeightOffset=%s, reverseOffset=%s, zOffset=%s, turnRadius=%s"):format(nameNum(vehicle), tostring(centerHeightOffset), tostring(turnInfo.reverseOffset), tostring(turnInfo.zOffset), tostring(turnInfo.turnRadius)), courseplay.DBG_TURN);
 
 		--- Get the 2 circle center cordinate
 		center1.x,_,center1.z = localToWorld(turnInfo.targetNode, centerOffset * turnInfo.direction, 0, centerHeightOffset);
@@ -747,7 +747,7 @@ function courseplay:generateTurnTypeQuestionmarkTurn(vehicle, turnInfo)
 			courseplay:generateTurnStraightPoints(vehicle, fromPoint, toPoint, true, nil, turnInfo.reverseWPChangeDistance);
 		end;
 
-		courseplay:debug(("%s:(Turn) centerHeightOffset=%s, reverseOffset=%s, zOffset=%s, turnRadius=%s"):format(nameNum(vehicle), tostring(centerHeightOffset), tostring(turnInfo.reverseOffset), tostring(turnInfo.zOffset), tostring(turnInfo.turnRadius)), courseplay.DBG_14);
+		courseplay:debug(("%s:(Turn) centerHeightOffset=%s, reverseOffset=%s, zOffset=%s, turnRadius=%s"):format(nameNum(vehicle), tostring(centerHeightOffset), tostring(turnInfo.reverseOffset), tostring(turnInfo.zOffset), tostring(turnInfo.turnRadius)), courseplay.DBG_TURN);
 
 		--- Get the 2 circle center cordinate
 		center1.x,_,center1.z = localToWorld(turnInfo.targetNode, (abs(turnInfo.targetDeltaX) + turnInfo.turnRadius) * turnInfo.direction, 0, newZOffset);
@@ -809,9 +809,9 @@ function courseplay:generateTurnTypeQuestionmarkTurn(vehicle, turnInfo)
 end;
 
 function courseplay:generateTurnTypeForward3PointTurn(vehicle, turnInfo)
-	courseplay.debugLine(courseplay.DBG_14, 3);
-	courseplay:debug(string.format("%s:(Turn) Using Forward 3 Point Turn", nameNum(vehicle)), courseplay.DBG_14);
-	courseplay.debugLine(courseplay.DBG_14, 3);
+	courseplay.debugLine(courseplay.DBG_TURN, 3);
+	courseplay:debug(string.format("%s:(Turn) Using Forward 3 Point Turn", nameNum(vehicle)), courseplay.DBG_TURN);
+	courseplay.debugLine(courseplay.DBG_TURN, 3);
 
 	local posX, posZ;
 	local fromPoint, toPoint = {}, {};
@@ -841,18 +841,18 @@ function courseplay:generateTurnTypeForward3PointTurn(vehicle, turnInfo)
 		if vehicle.cp.settings.oppositeTurnMode:is(true) then
 			width = turnInfo.onLaneNum * vehicle.cp.courseWorkWidth - (vehicle.cp.courseWorkWidth * 0.5);
 			doNormalTurn = widthNeeded > width;
-			courseplay:debug(("%s:(Turn) doNormalTurn=%s, %.1fm > %.1fm"):format(nameNum(vehicle), tostring(doNormalTurn), widthNeeded, width), courseplay.DBG_14);
+			courseplay:debug(("%s:(Turn) doNormalTurn=%s, %.1fm > %.1fm"):format(nameNum(vehicle), tostring(doNormalTurn), widthNeeded, width), courseplay.DBG_TURN);
 		else
 			width = (turnInfo.numLanes - turnInfo.onLaneNum) * vehicle.cp.courseWorkWidth - (vehicle.cp.courseWorkWidth * 0.5);
 			doNormalTurn = widthNeeded < width;
-			courseplay:debug(("%s:(Turn) doNormalTurn=%s, %.1fm < %.1fm"):format(nameNum(vehicle), tostring(doNormalTurn), widthNeeded, width), courseplay.DBG_14);
+			courseplay:debug(("%s:(Turn) doNormalTurn=%s, %.1fm < %.1fm"):format(nameNum(vehicle), tostring(doNormalTurn), widthNeeded, width), courseplay.DBG_TURN);
 		end;
 
 		if not doNormalTurn then
 			--- We don't have space on the side we want to turn into, so we do the turn in opposite direction
 			turnInfo.direction = turnInfo.direction * -1;
 		end;
-		courseplay:debug(("%s:(Turn) centerOffset=%s, centerHeight=%s"):format(nameNum(vehicle), tostring(turnInfo.centerOffset), tostring(turnInfo.centerHeight)), courseplay.DBG_14);
+		courseplay:debug(("%s:(Turn) centerOffset=%s, centerHeight=%s"):format(nameNum(vehicle), tostring(turnInfo.centerOffset), tostring(turnInfo.centerHeight)), courseplay.DBG_TURN);
 
 		--- Get the 2 circle center coordinate
 		center1.x,_,center1.z = localToWorld(turnInfo.targetNode, turnInfo.targetDeltaX - turnInfo.turnRadius * turnInfo.direction, 0, targetDeltaZ + turnInfo.zOffset + frontOffset);
@@ -944,9 +944,9 @@ function courseplay:generateTurnTypeForward3PointTurn(vehicle, turnInfo)
 end;
 
 function courseplay:generateTurnTypeReverse3PointTurn(vehicle, turnInfo)
-	courseplay.debugLine(courseplay.DBG_14, 3);
-	courseplay:debug(string.format("%s:(Turn) Using Reversing 3 Point Turn", nameNum(vehicle)), courseplay.DBG_14);
-	courseplay.debugLine(courseplay.DBG_14, 3);
+	courseplay.debugLine(courseplay.DBG_TURN, 3);
+	courseplay:debug(string.format("%s:(Turn) Using Reversing 3 Point Turn", nameNum(vehicle)), courseplay.DBG_TURN);
+	courseplay.debugLine(courseplay.DBG_TURN, 3);
 
 	local posX, posZ;
 	local fromPoint, toPoint = {}, {};
@@ -965,11 +965,11 @@ function courseplay:generateTurnTypeReverse3PointTurn(vehicle, turnInfo)
 	if vehicle.cp.settings.oppositeTurnMode:is(true) then
 		width = turnInfo.onLaneNum * vehicle.cp.courseWorkWidth - (vehicle.cp.courseWorkWidth * 0.5);
 		doNormalTurn = widthNeeded > width;
-		courseplay:debug(("%s:(Turn) doNormalTurn=%s, %.1fm > %.1fm"):format(nameNum(vehicle), tostring(doNormalTurn), widthNeeded, width), courseplay.DBG_14);
+		courseplay:debug(("%s:(Turn) doNormalTurn=%s, %.1fm > %.1fm"):format(nameNum(vehicle), tostring(doNormalTurn), widthNeeded, width), courseplay.DBG_TURN);
 	else
 		width = (turnInfo.numLanes - turnInfo.onLaneNum) * vehicle.cp.courseWorkWidth - (vehicle.cp.courseWorkWidth * 0.5);
 		doNormalTurn = widthNeeded < width;
-		courseplay:debug(("%s:(Turn) doNormalTurn=%s, %.1fm < %.1fm"):format(nameNum(vehicle), tostring(doNormalTurn), widthNeeded, width), courseplay.DBG_14);
+		courseplay:debug(("%s:(Turn) doNormalTurn=%s, %.1fm < %.1fm"):format(nameNum(vehicle), tostring(doNormalTurn), widthNeeded, width), courseplay.DBG_TURN);
 	end;
 
 	if not doNormalTurn then
@@ -1042,9 +1042,9 @@ end;
 -- forward on a curve, reaching the target direction at turnEnd
 ------------------------------------------------------------------------
 function courseplay.generateTurnTypeHeadlandCornerReverseWithCurve(vehicle, turnInfo)
-	courseplay.debugLine(courseplay.DBG_14, 3);
-	courseplay:debug(string.format("%s:(Turn) Using Headland Corner Turn", nameNum(vehicle)), courseplay.DBG_14);
-	courseplay.debugLine(courseplay.DBG_14, 3);
+	courseplay.debugLine(courseplay.DBG_TURN, 3);
+	courseplay:debug(string.format("%s:(Turn) Using Headland Corner Turn", nameNum(vehicle)), courseplay.DBG_TURN);
+	courseplay.debugLine(courseplay.DBG_TURN, 3);
 
 	local fromPoint, toPoint = {}, {};
 	local centerReverse, tempCenterReverse, centerForward, startDir, stopDir = {}, {}, {}, {}, {}
@@ -1136,9 +1136,9 @@ end;
 -- During this turn the vehicle does not leave the field (or the current headland)
 ------------------------------------------------------------------------
 function courseplay.generateTurnTypeHeadlandCornerReverseStraightCombine(vehicle, turnInfo)
-	courseplay.debugLine(courseplay.DBG_14, 3);
-	courseplay.debugVehicle( courseplay.DBG_14, vehicle, "(Turn) Using Headland Corner Reverse Turn" )
-	courseplay.debugLine(courseplay.DBG_14, 3);
+	courseplay.debugLine(courseplay.DBG_TURN, 3);
+	courseplay.debugVehicle( courseplay.DBG_TURN, vehicle, "(Turn) Using Headland Corner Reverse Turn" )
+	courseplay.debugLine(courseplay.DBG_TURN, 3);
 
 	local fromPoint, toPoint = {}, {};
 	local centerForward, startDir, stopDir = {}, {}, {}
@@ -1153,7 +1153,7 @@ function courseplay.generateTurnTypeHeadlandCornerReverseStraightCombine(vehicle
 	turnInfo.turnRadius = turnInfo.turnRadius * 1.1
 	local deltaZC = turnInfo.turnRadius / math.abs( math.tan( turnInfo.deltaAngle / 2 ))
 	centerForward.x,_,centerForward.z = localToWorld(turnStartNode, - turnInfo.direction * turnInfo.turnRadius, 0, -deltaZC )
-	courseplay.debugVehicle( courseplay.DBG_14, vehicle,
+	courseplay.debugVehicle( courseplay.DBG_TURN, vehicle,
 		"(Turn) courseplay:generateTurnTypeHeadlandCornerReverseStraightCombine(), fwdCircle( %.2f %.2f ), deltaAngle %.2f, deltaZC %.2f",
 		centerForward.x, centerForward.z, math.deg( turnInfo.deltaAngle ), deltaZC )
 
@@ -1162,7 +1162,7 @@ function courseplay.generateTurnTypeHeadlandCornerReverseStraightCombine(vehicle
 	-- we want the work area of our implement reach the edge of the field. We are on a headland, the field edge
 	-- is workwidth/2 from us, but our front marker must reach it.
 	toPoint.x, _, toPoint.z = localToWorld( turnStartNode, 0, 0, vehicle.cp.courseWorkWidth / 2 - turnInfo.frontMarker + turnInfo.wpChangeDistance + 0.5 )
-	courseplay.debugVehicle( courseplay.DBG_14, vehicle,
+	courseplay.debugVehicle( courseplay.DBG_TURN, vehicle,
 		"(Turn) courseplay:generateTurnTypeHeadlandCornerReverseStraightCombine(), from ( %.2f %.2f ), to ( %.2f %.2f) workWidth: %.1f, frontMarker: %.1f",
 		fromPoint.x, fromPoint.z, toPoint.x, toPoint.z, vehicle.cp.courseWorkWidth, turnInfo.frontMarker )
 	courseplay:generateTurnStraightPoints( vehicle, fromPoint, toPoint, false )
@@ -1203,9 +1203,9 @@ end;
 -- reverse back straight, then forward on a curve, then back up to the corner, lower implements there.
 ------------------------------------------------------------------------
 function courseplay.generateTurnTypeHeadlandCornerReverseStraightTractor(vehicle, turnInfo)
-	courseplay.debugLine(courseplay.DBG_14, 3);
-	courseplay:debug(string.format("%s:(Turn) Using Headland Corner Reverse Turn for tractors", nameNum(vehicle)), courseplay.DBG_14);
-	courseplay.debugLine(courseplay.DBG_14, 3);
+	courseplay.debugLine(courseplay.DBG_TURN, 3);
+	courseplay:debug(string.format("%s:(Turn) Using Headland Corner Reverse Turn for tractors", nameNum(vehicle)), courseplay.DBG_TURN);
+	courseplay.debugLine(courseplay.DBG_TURN, 3);
 
 	local fromPoint, toPoint = {}, {}
 	local centerForward = vehicle.cp.turnCorner:getArcCenter()
@@ -1222,7 +1222,7 @@ function courseplay.generateTurnTypeHeadlandCornerReverseStraightTractor(vehicle
 	local dx, dy, dz = worldToLocal( helperNode, toPoint.x, toPoint.y, toPoint.z )
 	-- at which waypoint we have to raise the implement
 	if dz > 0 then
-		courseplay:debug(("%s:(Turn) courseplay:generateTurnTypeHeadlandCornerReverseStraightTractor(), now driving forward so implement reaches headland"):format( nameNum( vehicle )), courseplay.DBG_14 )
+		courseplay:debug(("%s:(Turn) courseplay:generateTurnTypeHeadlandCornerReverseStraightTractor(), now driving forward so implement reaches headland"):format( nameNum( vehicle )), courseplay.DBG_TURN )
 		courseplay:generateTurnStraightPoints( vehicle, fromPoint, toPoint, false )
 		setTranslation(helperNode, dx, dy, dz)
 	end
@@ -1321,7 +1321,7 @@ function courseplay:getLaneInfo(vehicle)
 		end;
 	end;
 
-	courseplay:debug(("%s:(Turn) courseplay:getLaneInfo(), On Lane Nummber = %d, Number of Lanes = %d"):format(nameNum(vehicle), onLaneNum, numLanes), courseplay.DBG_14);
+	courseplay:debug(("%s:(Turn) courseplay:getLaneInfo(), On Lane Nummber = %d, Number of Lanes = %d"):format(nameNum(vehicle), onLaneNum, numLanes), courseplay.DBG_TURN);
 	return numLanes, onLaneNum;
 end;
 
@@ -1425,7 +1425,7 @@ function courseplay:generateTurnCircle(vehicle, center, startDir, stopDir, radiu
 			degreeToTurn = startRot - endRot;
 		end;
 	end;
-	courseplay:debug(string.format("%s:(Turn:generateTurnCircle) startRot=%d, endRot=%d, degreeStep=%d, degreeToTurn=%d, clockwise=%d", nameNum(vehicle), startRot, endRot, (degreeStep * clockwise), degreeToTurn, clockwise), courseplay.DBG_14);
+	courseplay:debug(string.format("%s:(Turn:generateTurnCircle) startRot=%d, endRot=%d, degreeStep=%d, degreeToTurn=%d, clockwise=%d", nameNum(vehicle), startRot, endRot, (degreeStep * clockwise), degreeToTurn, clockwise), courseplay.DBG_TURN);
 
 	-- Get the number of waypoints
 	numWP = ceil(degreeToTurn / degreeStep);
@@ -1434,7 +1434,7 @@ function courseplay:generateTurnCircle(vehicle, center, startDir, stopDir, radiu
 	-- Add extra waypoint if addEndPoint is true
 	if addEndPoint then numWP = numWP + 1; end;
 
-	courseplay:debug(string.format("%s:(Turn:generateTurnCircle) numberOfWaypoints=%d, newDegreeStep=%d", nameNum(vehicle), numWP, degreeStep), courseplay.DBG_14);
+	courseplay:debug(string.format("%s:(Turn:generateTurnCircle) numberOfWaypoints=%d, newDegreeStep=%d", nameNum(vehicle), numWP, degreeStep), courseplay.DBG_TURN);
 
 	-- Generate the waypoints
 	local i = 1;
@@ -1450,7 +1450,7 @@ function courseplay:generateTurnCircle(vehicle, center, startDir, stopDir, radiu
 		courseplay:addTurnTarget(vehicle, posX, posZ, nil, reverse, nil, nil, true);
 
 		local _,rot,_ = getRotation(point);
-		courseplay:debug(string.format("%s:(Turn:generateTurnCircle) waypoint %d curentRotation=%d", nameNum(vehicle), i, deg(rot)), courseplay.DBG_14);
+		courseplay:debug(string.format("%s:(Turn:generateTurnCircle) waypoint %d curentRotation=%d", nameNum(vehicle), i, deg(rot)), courseplay.DBG_TURN);
 	end;
 
 	-- Clean up the created node.
@@ -1470,7 +1470,7 @@ function courseplay:addTurnTarget(vehicle, posX, posZ, turnEnd, turnReverse, rev
 	table.insert(vehicle.cp.turnTargets, target);
 
 	if not dontPrint then
-		courseplay:debug(("%s:(Turn:addTurnTarget %d) posX=%.2f, posZ=%.2f, turnEnd=%s, turnReverse=%s, changeDirectionWhenAligned=%s"):format(nameNum(vehicle), #vehicle.cp.turnTargets, posX, posZ, tostring(turnEnd and true or false), tostring(turnReverse and true or false), tostring(changeDirectionWhenAligned and true or false)), courseplay.DBG_14);
+		courseplay:debug(("%s:(Turn:addTurnTarget %d) posX=%.2f, posZ=%.2f, turnEnd=%s, turnReverse=%s, changeDirectionWhenAligned=%s"):format(nameNum(vehicle), #vehicle.cp.turnTargets, posX, posZ, tostring(turnEnd and true or false), tostring(turnReverse and true or false), tostring(changeDirectionWhenAligned and true or false)), courseplay.DBG_TURN);
 	end;
 end
 
@@ -1550,7 +1550,7 @@ function courseplay:getAlignWpsToTargetWaypoint( vehicle, vx, vz, tx, tz, tDirec
 	local angleBetweenTangentAndC1 = math.pi / 2 - math.asin( turnRadius / vehicleToC1Distance )
 	-- check for NaN, may happen when we are closer than turnRadius
 	if angleBetweenTangentAndC1 ~= angleBetweenTangentAndC1 then
-		courseplay.debugVehicle(courseplay.DBG_14, vehicle, "can't create alignment course, r=%.1f, c-v=%.1f", turnRadius, vehicleToC1Distance)
+		courseplay.debugVehicle(courseplay.DBG_TURN, vehicle, "can't create alignment course, r=%.1f, c-v=%.1f", turnRadius, vehicleToC1Distance)
 		courseplay.destroyNode( wpNode )
 		return nil
 	end
@@ -1598,7 +1598,7 @@ Corner = CpObject()
 ---@param offsetX number left/right offset of the course. The Corner uses the un-offset coordinates of the start/end
 --- waypoints and the offsetX to move the corner point diagonally inward or outward if the course has a side offset
 function Corner:init(vehicle, startAngleDeg, startWp, endAngleDeg, endWp, turnRadius, offsetX)
-	self.debugChannel = courseplay.DBG_14
+	self.debugChannel = courseplay.DBG_TURN
 	self.vehicle = vehicle
 	self.startWp = startWp
 	self.endWp = endWp
@@ -2099,7 +2099,7 @@ end
 function TurnContext:createCorner(vehicle, r, sideOffset)
 	-- use the average angle of the turn end and the next wp as there is often a bend there
 	local endAngleDeg = self:getAverageEndAngleDeg()
-	courseplay.debugVehicle(courseplay.DBG_14, vehicle, 'start angle: %.1f, end angle: %.1f (from %.1f and %.1f)', self.beforeTurnStartWp.angle,
+	courseplay.debugVehicle(courseplay.DBG_TURN, vehicle, 'start angle: %.1f, end angle: %.1f (from %.1f and %.1f)', self.beforeTurnStartWp.angle,
 		endAngleDeg, self.turnEndWp.angle, self.afterTurnEndWp.angle)
 	return Corner(vehicle, self.beforeTurnStartWp.angle, self.turnStartWp, endAngleDeg, self.turnEndWp, r,
 			sideOffset or vehicle.cp.settings.toolOffsetX:get())

--- a/vehicles.lua
+++ b/vehicles.lua
@@ -320,18 +320,21 @@ function courseplay:getDirectionNodeToTurnNodeLength(vehicle)
 
 					if workToolDistances.attacherJointToPivot then
 						totalDistance = totalDistance + workToolDistances.attacherJointToPivot;
-						courseplay:debug(('getDirectionNodeToTurnNodeLength() -> %s: attacherJointToPivot=%.2fm'):format(nameNum(workTool), workToolDistances.attacherJointToPivot), courseplay.DBG_14);
+						courseplay:debug(('getDirectionNodeToTurnNodeLength() -> %s: attacherJointToPivot=%.2fm'):format(
+							nameNum(workTool), workToolDistances.attacherJointToPivot), courseplay.DBG_IMPLEMENTS);
 					end;
 
 					totalDistance = totalDistance + workToolDistances.attacherJointOrPivotToTurningNode;
-					courseplay:debug(('getDirectionNodeToTurnNodeLength() -> %s: attacherJointOrPivotToTurningNode=%.2fm'):format(nameNum(workTool), workToolDistances.attacherJointOrPivotToTurningNode), courseplay.DBG_14);
-					courseplay:debug(('getDirectionNodeToTurnNodeLength() -> %s: attacherJointToTurningNode=%.2fm'):format(nameNum(workTool), totalDistance), courseplay.DBG_14);
+					courseplay:debug(('getDirectionNodeToTurnNodeLength() -> %s: attacherJointOrPivotToTurningNode=%.2fm'):format(
+						nameNum(workTool), workToolDistances.attacherJointOrPivotToTurningNode), courseplay.DBG_IMPLEMENTS);
+					courseplay:debug(('getDirectionNodeToTurnNodeLength() -> %s: attacherJointToTurningNode=%.2fm'):format(
+						nameNum(workTool), totalDistance), courseplay.DBG_IMPLEMENTS);
 				else
 					if not distances.attacherJointOrPivotToTurningNode and distances.attacherJointToRearTrailerAttacherJoints then
 						totalDistance = totalDistance + distances.attacherJointToRearTrailerAttacherJoints[activeInputAttacherJoint.jointType];
 					end;
 					totalDistance = totalDistance + courseplay:getDirectionNodeToTurnNodeLength(workTool);
-					--courseplay:debug(('%s: directionNodeToTurnNodeLength=%.2fm'):format(nameNum(workTool), totalDistance), courseplay.DBG_14);
+					--courseplay:debug(('%s: directionNodeToTurnNodeLength=%.2fm'):format(nameNum(workTool), totalDistance), courseplay.DBG_IMPLEMENTS);
 				end;
 				break;
 			end;
@@ -347,7 +350,8 @@ function courseplay:getDirectionNodeToTurnNodeLength(vehicle)
 				end;
 			end;
 			vehicle.cp.directionNodeToTurnNodeLength = totalDistance;
-			courseplay:debug(('getDirectionNodeToTurnNodeLength() -> %s: directionNodeToTurnNodeLength=%.2fm'):format(nameNum(vehicle), totalDistance), courseplay.DBG_14);
+			courseplay:debug(('getDirectionNodeToTurnNodeLength() -> %s: directionNodeToTurnNodeLength=%.2fm'):format(
+				nameNum(vehicle), totalDistance), courseplay.DBG_IMPLEMENTS);
 		end;
 	end;
 
@@ -1494,7 +1498,9 @@ function AIDriverUtil.calculateTightTurnOffset(vehicle, course, previousOffset, 
 
     -- smooth the offset a bit to avoid sudden changes
     tightTurnOffset = smoothOffset(offset)
-    courseplay.debugVehicle(courseplay.DBG_14, vehicle, 'Tight turn, r = %.1f, tow bar = %.1f m, currentAngle = %.0f, nextAngle = %.0f, offset = %.1f, smoothOffset = %.1f',	r, towBarLength, currentAngle, nextAngle, offset, tightTurnOffset )
+    courseplay.debugVehicle(courseplay.DBG_AI_DRIVER, vehicle,
+		'Tight turn, r = %.1f, tow bar = %.1f m, currentAngle = %.0f, nextAngle = %.0f, offset = %.1f, smoothOffset = %.1f',
+		r, towBarLength, currentAngle, nextAngle, offset, tightTurnOffset )
     -- remember the last value for smoothing
     return tightTurnOffset
 end


### PR DESCRIPTION
 Reassign debug channels as the current assignment to functions/modes is chaotic and there are a lot of unused channels.
I would like to sort the Channels new.
Like we have a Problem in Mode2: We need Channel 2 (for Mode2) and Pathfinding Debug (e.g. Channel 11).

- [x] DBG1 = Mode1
- [x] DBG2 = Mode2
- [x] DBG3 = Mode3
- [x] DBG4 = Mode4
- [x] DBG5 = Mode5
- [x] DBG6 = Mode6
- [x] DBG7 = Mode7
- [x] DBG8 = Mode8
- [x] DBG9 = Mode9
- [x] DBG10 = Mode10

- [x] DBG11 = Pathfinder (before: 7)
- [x] DBG12 = Trigger (before: 1 or 2 ? not sure about difference)

For Driving Stuff (Old channel 12, 13, 14, and so on) I would split on, maybe like that:
- [x] DBG13 = reverse driving
- [x] DBG14 = turn
- [x] DBG15 = PPC (if it makes sence to have its own dbg channel)
- [x] DBG16 = Load/unload
- [x] DBG17 = Traffic
- [x] DBG20 = Multiplayer
...

- [ ] Most Important is to have channel 12 splitted, as it prints to many debugs that you don't need sometimes.