### PR TITLE
6.03.00052 Bale Collector and Pathfinder Fixes (Issue #7014)

### DIFF
--- a/BaleCollectorAIDriver.lua
+++ b/BaleCollectorAIDriver.lua
@@ -178,7 +178,10 @@ function BaleCollectorAIDriver:findPathToNextBale()
 	if not self.bales then return end
 	local bale, d, ix = self:findClosestBale(self.bales)
 	if ix then
-		if not self:isObstacleAhead() then
+		if bale:isLoaded() then
+			self:debug('Bale %d is already loaded, skipping', bale:getId())
+			table.remove(self.bales, ix)
+		elseif not self:isObstacleAhead() then
 			self:startPathfindingToBale(bale)
 			-- remove bale from list
 			table.remove(self.bales, ix)

--- a/BaleToCollect.lua
+++ b/BaleToCollect.lua
@@ -88,6 +88,8 @@ end
 function BaleToCollect:getSafeDistance()
 	-- round bales don't have length, just diameter
 	local length = self.bale.baleDiameter and self.bale.baleDiameter or self.bale.baleLength
-	-- no matter what kind of bale, the footprint is a rectangle, get the diagonal
-	return math.sqrt(length * length + self.bale.baleWidth * self.bale.baleWidth) / 2
+	-- no matter what kind of bale, the footprint is a rectangle, get the diagonal (which, is BTW, not
+	-- exact math as it depends on the angle we are approaching the bale, so add a little buffer instead of
+	-- thinking about the math...
+	return math.sqrt(length * length + self.bale.baleWidth * self.bale.baleWidth) / 2 + 0.2
 end

--- a/BaleToCollect.lua
+++ b/BaleToCollect.lua
@@ -56,6 +56,10 @@ function BaleToCollect.isValidBale(object, baleWrapper)
 	end
 end
 
+function BaleToCollect:isLoaded()
+	return self.bale.mountObject
+end
+
 function BaleToCollect:getFieldId()
 	return self.fieldId
 end

--- a/DevHelper.lua
+++ b/DevHelper.lua
@@ -154,6 +154,7 @@ function DevHelper:keyEvent(unicode, sym, modifier, isDown)
         -- Left Alt + < mark start
         self.start = State3D(self.data.x, -self.data.z, courseGenerator.fromCpAngleDeg(self.data.yRotDeg))
         self:debug('Start %s', tostring(self.start))
+		PathfinderUtil.checkForObstaclesAhead(self.vehicle, 6)
     elseif bitAND(modifier, Input.MOD_LALT) ~= 0 and isDown and sym == Input.KEY_period then
         -- Left Alt + > mark goal
         self.goal = State3D(self.data.x, -self.data.z, courseGenerator.fromCpAngleDeg(self.data.yRotDeg))

--- a/DevHelper.lua
+++ b/DevHelper.lua
@@ -43,7 +43,6 @@ function DevHelper:update()
     if g_currentMission.controlledVehicle and g_currentMission.controlledVehicle.spec_aiVehicle then
 
         if self.vehicle ~= g_currentMission.controlledVehicle then
-            self.otherVehiclesCollisionData = PathfinderUtil.setUpVehicleCollisionData(g_currentMission.controlledVehicle)
             self.vehicleData = PathfinderUtil.VehicleData(g_currentMission.controlledVehicle, true)
         end
 
@@ -61,20 +60,6 @@ function DevHelper:update()
         else
             self.proxySensor:update()
             self.proxySensor:showDebugInfo()
-        end
-    end
-
-    if self.vehicleData then
-        self.collisionData = PathfinderUtil.getBoundingBoxInWorldCoordinates(self.node, self.vehicleData, 'me')
-        hasCollision, vehicle = PathfinderUtil.findCollidingVehicles(
-                self.collisionData,
-                self.node,
-                self.vehicleData,
-                self.otherVehiclesCollisionData)
-        if hasCollision then
-            self.data.vehicleOverlap = vehicle
-        else
-            self.data.vehicleOverlap = 'none'
         end
     end
 
@@ -103,7 +88,8 @@ function DevHelper:update()
 	self.data.tzRotDeg = math.deg(zRot)
 
     self.data.collidingShapes = ''
-    overlapBox(self.data.x, self.data.y + 0.2, self.data.z, 0, self.yRot, 0, 1.6, 1, 8, "overlapBoxCallback", self, bitOR(AIVehicleUtil.COLLISION_MASK, 2), true, true, true)
+    overlapBox(self.data.x, self.data.y + 0.2, self.data.z, 0, self.yRot, 0, 1.6, 1, 8, "overlapBoxCallback", self,
+		bitOR(AIVehicleUtil.COLLISION_MASK, 2), true, true, true)
 
     if self.pathfinder and self.pathfinder:isActive() then
         local done, path = self.pathfinder:resume()
@@ -333,6 +319,7 @@ function DevHelper:showVehicleSize()
             drawDebugLine(x3,y3,z3,0.2, 0.2 ,1,x4,y4,z4,0.2, 0.2,1);
         end
         if self.vehicleData.trailerRectangle then
+			PathfinderUtil.initializeTrailerHeading(node, self.vehicleData)
             local x, y, z = localToWorld(g_devHelper.helperNode, 0, 0, self.vehicleData.trailerHitchOffset)
             setTranslation(g_devHelper.helperNode, x, y, z)
             setRotation(g_devHelper.helperNode, 0, courseGenerator.toCpAngle(node.tTrailer), 0)
@@ -345,13 +332,6 @@ function DevHelper:showVehicleSize()
             drawDebugLine(x1,y1,z1,0,1,0,x3,y3,z3,0,1,0);
             drawDebugLine(x2,y2,z2,0,1,0,x4,y4,z4,0,1,0);
             drawDebugLine(x3,y3,z3,0,1,0,x4,y4,z4,0,1,0);
-        end
-    end
-    if self.collisionData then
-        for i = 1, 4 do
-            local cp = self.collisionData.corners[i]
-            local pp = self.collisionData.corners[i > 1 and i - 1 or 4]
-            cpDebug:drawLine(cp.x, cp.y + 0.4, cp.z, 1, 0, 0, pp.x, pp.y + 0.4, pp.z)
         end
     end
     DebugUtil.drawDebugNode(g_devHelper.helperNode, 'devhelper')

--- a/course-generator/.editorconfig
+++ b/course-generator/.editorconfig
@@ -5,4 +5,4 @@ end_of_line = lf
 # tab indentation
 [*.{xml,lua}]
 indent_style = tab
-indent_size = 2
+indent_size = 4

--- a/course-generator/HybridAStar.lua
+++ b/course-generator/HybridAStar.lua
@@ -791,7 +791,7 @@ function HybridAStarWithAStarInTheMiddle:resume(...)
 				end
 			end
 		elseif self.phase == self.MIDDLE then
-			if not path then return true, nil end
+			if not path then return true, nil, goalNodeInvalid end
 			local lMiddlePath = HybridAStar.length(path)
 			self:debug('Direct path is %d m', lMiddlePath)
 			-- do we even need to use the normal A star or the nodes are close enough that the hybrid A star will be fast enough?

--- a/course-generator/PathfinderUtil.lua
+++ b/course-generator/PathfinderUtil.lua
@@ -796,7 +796,6 @@ function PathfinderUtil.checkForObstaclesAhead(vehicle, turnRadius)
 		local yRot = MathUtil.getYRotationFromDirection(dx, dz)
 		setRotation(PathfinderUtil.helperNode, 0, yRot, 0)
 		local path, len = PathfinderUtil.findDubinsPath(vehicle, 0, PathfinderUtil.helperNode, 0, 0, turnRadius)
-		courseplay.debugFormat(courseplay.DBG_PATHFINDER, '  path length %.1f m', len)
 		-- making sure we continue with the correct trailer heading
 		path[1]:setTrailerHeading(start:getTrailerHeading())
 		State3D.calculateTrailerHeadings(path, hitchLength)

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="47">
-	<version>6.03.00051</version>
+	<version>6.03.00052</version>
 	<author><![CDATA[Courseplay.devTeam]]></author>
 	<title><!-- en=English de=German fr=French es=Spanish ru=Russian pl=Polish it=Italian br=Brazilian-Portuguese cs=Chinese(Simplified) ct=Chinese(Traditional) cz=Czech nl=Netherlands hu=Hungary jp=Japanese kr=Korean pt=Portuguese ro=Romanian tr=Turkish -->
 		<en>CoursePlay SIX</en>

--- a/start_stop.lua
+++ b/start_stop.lua
@@ -267,8 +267,6 @@ function courseplay:stop(self)
 	courseplay:resetCustomTimer(self, 'slippingStage1');
 	courseplay:resetCustomTimer(self, 'slippingStage2');
 
-	courseplay:resetCustomTimer(self, 'foldBaleLoader', true);
-
 	self.cp.hasBaleLoader = false;
 	
 	if self.cp.manualWorkWidth ~= nil then


### PR DESCRIPTION
- bale collector checks for obstacles ahead before starting the pathfinding
- reverse after pathfinding fails twice and we are on the field edge
- skip bales loaded by someone else
- add a buffer to the bale size when calculating the target, so the
pathfinder does not detect a collision at the target bale

- vehicle and trailer overlap box positioning for the collision detection
fixed, they were off to the back, causing false alarms.
- removed obsolete overlap rectangle check with other vehicles, that
was a brain fart, there is no need to do that, the overlapBox does
that anyway.
- trailer overlap box is now correctly rotated around the hitch, resulting
in better obstacle avoidance with trailer