### PR TITLE
A couple of tweaks to how pathfinding works for the combineunloadaidr…

### DIFF
--- a/CombineAIDriver.lua
+++ b/CombineAIDriver.lua
@@ -692,7 +692,7 @@ function CombineAIDriver:getUnloaderRendezvousWaypoint(unloaderEstimatedSecondsE
 	-- rendezvous at whichever is closer
 	unloaderRendezvousWaypointIx = math.min(unloaderRendezvousWaypointIx, self.waypointIxWhenFull or unloaderRendezvousWaypointIx)
 	-- now check if this is a good idea
-	self.agreedUnloaderRendezvousWaypointIx = self:findBestWaypointToUnload(unloaderRendezvousWaypointIx, unloadAIDriver)
+	self.agreedUnloaderRendezvousWaypointIx = self:findBestWaypointToUnload(unloaderRendezvousWaypointIx, unloadAIDriver.vehicle.cp.settings.useRealisticDriving:is(false))
 	if self.agreedUnloaderRendezvousWaypointIx then
 		self.unloadAIDriverToRendezvous:set(unloadAIDriver, 1000 * (unloaderEstimatedSecondsEnroute + 30))
 		self:debug('Rendezvous with unloader at waypoint %d in %d m', self.agreedUnloaderRendezvousWaypointIx, dToUnloaderRendezvous)
@@ -751,11 +751,11 @@ end
 --- we'll rendezvous the unloader or we'll be full there.
 ---@return number best waypoint to unload, ix may be adjusted to make sure it isn't in a turn or
 --- the fruit is not in the pipe.
-function CombineAIDriver:findBestWaypointToUnload(ix, unloadAIDriver)
+function CombineAIDriver:findBestWaypointToUnload(ix, isPipeInFruitAllowed)
 	if self.fieldworkCourse:isOnHeadland(ix) then
 		return self:findBestWaypointToUnloadOnHeadland(ix)
 	else
-		return self:findBestWaypointToUnloadOnUpDownRows(ix, unloadAIDriver)
+		return self:findBestWaypointToUnloadOnUpDownRows(ix, isPipeInFruitAllowed)
 	end
 end
 
@@ -777,7 +777,7 @@ end
 --- We calculated a waypoint to meet the unloader (either because it asked for it or we think we'll need
 --- to unload. Now make sure that this location is not around a turn or the pipe isn't in the fruit by
 --- trying to move it up or down a bit. If that's not possible, just leave it and see what happens :)
-function CombineAIDriver:findBestWaypointToUnloadOnUpDownRows(ix, unloadAIDriver)
+function CombineAIDriver:findBestWaypointToUnloadOnUpDownRows(ix, isPipeInFruitAllowed)
 	local dToNextTurn = self.fieldworkCourse:getDistanceToNextTurn(ix) or math.huge
 	local lRow, ixAtRowStart = self.fieldworkCourse:getRowLength(ix)
 	local pipeInFruit = self.fieldworkCourse:isPipeInFruitAt(ix)
@@ -785,7 +785,7 @@ function CombineAIDriver:findBestWaypointToUnloadOnUpDownRows(ix, unloadAIDriver
 	local newWpIx = ix
 	self:debug('Looking for a waypoint to unload around %d on up/down row, pipe in fruit %s, dToNextTurn: %d m, lRow = %d m',
 				ix, tostring(pipeInFruit), dToNextTurn, lRow or 0)
-	if pipeInFruit and unloadAIDriver.vehicle.cp.settings.useRealisticDriving:is(true) then --if the pipe is in fruit AND the user selects 'avoid fruit'
+	if pipeInFruit and not isPipeInFruitAllowed then --if the pipe is in fruit AND the user selects 'avoid fruit'
 		if ixAtRowStart then
 			if ixAtRowStart > currentIx then
 				-- have not started the previous row yet
@@ -812,7 +812,11 @@ function CombineAIDriver:findBestWaypointToUnloadOnUpDownRows(ix, unloadAIDriver
 			newWpIx = nil
 		end
 	else
-		self:debug('pipe is not in fruit at %d. If it is towards the end of the row, bring it up a bit', ix)
+		if (pipeInFruit) then
+			self:debug('pipe would be in fruite at waypoint %d, acceptable for user', ix)
+		else
+			self:debug('pipe is not in fruit at %d. If it is towards the end of the row, bring it up a bit', ix)
+		end
 		-- so we'll have some distance for unloading
 		if ixAtRowStart and dToNextTurn < CombineAIDriver.safeUnloadDistanceBeforeEndOfRow then
 			local safeIx = self.fieldworkCourse:getPreviousWaypointIxWithinDistance(ix,

--- a/CombineUnloadAIDriver.lua
+++ b/CombineUnloadAIDriver.lua
@@ -1260,7 +1260,7 @@ function CombineUnloadAIDriver:startDrivingToCombine()
 			-- (short) pathfinding to get under the pipe.
 			zOffset = - self:getCombinesMeasuredBackDistance() - 10
 		else
-			zOffset = - self:getCombinesMeasuredBackDistance() - 2
+			zOffset = - self:getCombinesMeasuredBackDistance() - 10 --allow trailer space to align after sharp turns (noticed it more affects potato/sugarbeet harvesters with pipes close to vehicle)
 		end
 		self:startPathfindingToCombine(self.onPathfindingDoneToCombine, nil, zOffset)
 	else


### PR DESCRIPTION
…iver to make sure there is enough space to straighten trailer behind the stopped harvester, and also to allow rendezvous points in fruit if the "avoid fruit" option is disabled

This was mainly noticed by me while playing and using the potato harvester where the combi unloader would cut in at awkward angles behind the harvester or wouldn't be able to pathfind into fruit areas even when the "Avoid fruit" option was disabled.