### PR TITLE
Tweak to the FollowChopperThroughTurn function to allow the user defi…

### DIFF
--- a/CombineUnloadAIDriver.lua
+++ b/CombineUnloadAIDriver.lua
@@ -2069,7 +2069,8 @@ function CombineUnloadAIDriver:followChopperThroughTurn()
 		-- follow course, make sure we are keeping distance from the chopper
 		-- TODO: or just rely on the proximity sensor here?
 		local combineSpeed = (self.combineToUnload.lastSpeedReal * 3600)
-		local speed = combineSpeed + MathUtil.clamp(d - self.minDistanceFromWideTurnChopper, -combineSpeed, self:getFieldSpeed())
+		local speed = combineSpeed + MathUtil.clamp(d - (self.minDistanceFromWideTurnChopper - self.settings.combineOffsetZ:get()),
+			-combineSpeed, self:getFieldSpeed())
 		self:setSpeed(speed)
 		self:renderText(0, 0.7, 'd = %.1f, speed = %.1f', d, speed)
 	else


### PR DESCRIPTION
…ned vertical offset to control how close to the chopper the unload driver can get.

When turning between rows, for the New Holland default Chopper FR 780 with some large tractors, the trailer is not quite within range of the pipe. This allows the user setting for VerticalOffset to allow the unload driver to move forward more than usual to get closer to the chopper during a row turn. Just something small I had noticed with one of the Large tractors and the FR 780 when chopping corn.

![image](https://user-images.githubusercontent.com/49454254/125128725-57876600-e0f6-11eb-815b-94c4ed5967eb.png)
