### PR TITLE
Link to website fixed in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ Wir haben eine Courseplay-Website mit allen möglichen Informationen, Anleitunge
 
 Go check out the **[Courseplay Homepage][CP Website Link]**
 
-[CP Website Link]: http://courseplay.github.com/courseplay/
+[CP Website Link]: https://courseplay.github.io/courseplay/
 ___
 
 ## Developer version 


### PR DESCRIPTION
Github changed URL for websites. "courseplay.github.com" is no longer accessible (404 error).
Changed to "courseplay.github.io".