### PR TITLE
Update GlobalInfoTextHandler.lua

### DIFF
--- a/GlobalInfoTextHandler.lua
+++ b/GlobalInfoTextHandler.lua
@@ -344,7 +344,8 @@ end
 ---@param isUp boolean the mouse button up ?
 ---@param mouseKey number mouse button was pressed ?
 function GlobalInfoTextHandler:onSecondaryMouseClick(posX, posY, isDown, isUp, mouseKey)
-	if self.hasContent and not self.playerOnFootMouseEnabled and not g_currentMission.player.currentTool then
+	if not self.hasContent then return; end;
+	if not self.playerOnFootMouseEnabled and not g_currentMission.player.currentTool then
 		self.playerOnFootMouseEnabled = true
 		self.wasPlayerFrozen = g_currentMission.isPlayerFrozen
 		g_currentMission.isPlayerFrozen = true


### PR DESCRIPTION
If self.hasContent is false, skip the handling of the rightmousebutten at all. 
This prevents it from disabling the mouse when some other mod might want to use the mouse.

I hope I'm doing it right this way, it's my first time doing it, so bear with me ;)
See my issue: https://github.com/Courseplay/courseplay/issues/7419