### PR TITLE
Fix offset course for multitool

### DIFF
--- a/test/mock-GiantsEngine.lua
+++ b/test/mock-GiantsEngine.lua
@@ -40,6 +40,7 @@ Cylindered = {}
 
 Utils = {}
 Utils.appendedFunction = noOp
+Utils.overwrittenFunction = noOp
 
 MathUtil = {}
 function MathUtil.vector2Length(x, y)


### PR DESCRIPTION
When calculating the offset course we marked each waypoint on the
headland with lane = -1 for simplicity but that means that all
waypoints of the headland seem to be on the outermost headland.

Since the pathfinder turn drives on the outermost headland this
confused the algorithm completely and resulted in paths going
the wrong way around the field.

Change offset calculation so offset course keeps the original
lane number.