### PR TITLE
Fix crash when pathfinding with sugarcane trailers

### DIFF
--- a/AIDriverUtil.lua
+++ b/AIDriverUtil.lua
@@ -109,13 +109,16 @@ function AIDriverUtil.getTowBarLength(vehicle)
 	-- is there a wheeled implement behind the tractor and is it on a pivot?
 	local workTool = courseplay:getFirstReversingWheeledWorkTool(vehicle)
 	if not workTool or not workTool.cp.realTurningNode then
-		return 0
+		courseplay.debugVehicle(courseplay.DBG_AI_DRIVER, vehicle, 'could not get tow bar length, using default 3 m.')
+		-- default is not 0 as this is used to calculate trailer heading and 0 here may result in NaNs
+		return 3
 	end
 	-- get the distance between the tractor and the towed implement's turn node
 	-- (not quite accurate when the angle between the tractor and the tool is high)
 	local tractorX, _, tractorZ = getWorldTranslation(AIDriverUtil.getDirectionNode(vehicle))
 	local toolX, _, toolZ = getWorldTranslation( workTool.cp.realTurningNode )
 	local towBarLength = courseplay:distance( tractorX, tractorZ, toolX, toolZ )
+	courseplay.debugVehicle(courseplay.DBG_AI_DRIVER, vehicle, 'tow bar length is %.1f.', towBarLength)
 	return towBarLength
 end
 

--- a/reverse.lua
+++ b/reverse.lua
@@ -420,8 +420,8 @@ function courseplay:getReverseProperties(vehicle, workTool)
 		courseplay:debug('--> vehicle has "Shovel" spec -> return', courseplay.DBG_REVERSE);
 		return;
 	end;
-	if workTool.cp.hasSpecializationShovel then
-		courseplay:debug('--> workTool has "Shovel" spec -> return', courseplay.DBG_REVERSE);
+	if workTool.cp.hasSpecializationShovel and not courseplay:isWheeledWorkTool(workTool) then
+		courseplay:debug('--> workTool has "Shovel" spec and has no wheels -> return', courseplay.DBG_REVERSE);
 		return;
 	end;
 	if not courseplay:isWheeledWorkTool(workTool) or courseplay:isHookLift(workTool) or courseplay:isAttacherModule(workTool) then

--- a/reverse.lua
+++ b/reverse.lua
@@ -420,6 +420,9 @@ function courseplay:getReverseProperties(vehicle, workTool)
 		courseplay:debug('--> vehicle has "Shovel" spec -> return', courseplay.DBG_REVERSE);
 		return;
 	end;
+	-- Sugarcane trailer for some reason also have a shovel specialization but we still want to use
+	-- them as trailers and reverse them, for which we need the realTurningNode which is set below.
+	-- So only ignore tools which do have a shovel but no wheel...
 	if workTool.cp.hasSpecializationShovel and not courseplay:isWheeledWorkTool(workTool) then
 		courseplay:debug('--> workTool has "Shovel" spec and has no wheels -> return', courseplay.DBG_REVERSE);
 		return;
@@ -437,6 +440,8 @@ function courseplay:getReverseProperties(vehicle, workTool)
 		workTool.cp.distances = courseplay:getDistances(workTool);
 	end;
 
+	-- TODO: figure out why these are only set for reversing, one would think they are pretty generic
+	-- and should be set in all cases...
 	workTool.cp.realTurningNode = courseplay:getRealTurningNode(workTool);
 
 	workTool.cp.realUnloadOrFillNode = courseplay:getRealUnloadOrFillNode(workTool);


### PR DESCRIPTION
Sugarcane trailers for some reason have a shovel specialization
which prevented CP from setting the reversing properties,
including the realTurningNode. This resulted in a 0 meter
tow bar length, resulting in Nans in the math calculating the trailer
heading.

Change reverse property calculation to ignore shovel only if
the implement has no wheels.