### PR TITLE
Consider MotorStartTime

### DIFF
--- a/register.lua
+++ b/register.lua
@@ -219,6 +219,9 @@ print(string.format('### Courseplay: installed into %d vehicle types', numInstal
 -- This fixes the problems with driveInDirection motor and cruise control. There is a bug some where that is setting self.rotatedTime to 0
 local originaldriveInDirection = AIVehicleUtil.driveInDirection;
 AIVehicleUtil.driveInDirection = function (self, dt, steeringAngleLimit, acceleration, slowAcceleration, slowAngleLimit, allowedToDrive, moveForwards, lx, lz, maxSpeed, slowDownFactor)
+	if self.getMotorStartTime ~= nil then
+		allowedToDrive = allowedToDrive and (self:getMotorStartTime() <= g_currentMission.time)
+	end
 
 	local angle = 0;
     if lx ~= nil and lz ~= nil then


### PR DESCRIPTION
Currently AIVehicleUtil.driveInDirection does not care with MotorStartTime of vehicles, which cause them to start driving even the engine is not complete started.
If vehicle is not controlled by CP, i.e. AD, it might move even back instead of do not move at all, see: https://youtu.be/8JXEZ8NP5g8
This change holds the vehicle until engine is completely started.